### PR TITLE
PILATES managed updates

### DIFF
--- a/baus/models.py
+++ b/baus/models.py
@@ -21,6 +21,7 @@ import pandas as pd
 from variable_generators import generators
 import copy
 
+
 @orca.step()
 def elcm_simulate(jobs, buildings, aggregations, zones, elcm_config):
     buildings.local["non_residential_rent"] = \
@@ -1044,7 +1045,7 @@ def generate_skims_vars():
     """
     This model step just aggregates a bunch of variables to
     the zone level and lazily defines them as  new columns in the
-    zones table. Only columns used in creating skim-based 
+    zones table. Only columns used in creating skim-based
     accessibility variables are required to be generated here
     so it might be useful in the future to clean this section up.
     """

--- a/baus/models.py
+++ b/baus/models.py
@@ -6,7 +6,7 @@ import yaml
 import datasources
 import variables
 from utils import parcel_id_to_geom_id, geom_id_to_parcel_id, \
-    add_buildings, run_feasibility
+    add_buildings, run_feasibility, register_skim_access_variable
 from utils import round_series_match_target, groupby_random_choice
 from urbansim.utils import networks
 import pandana.network as pdna
@@ -18,7 +18,8 @@ import subsidies
 import summaries
 import numpy as np
 import pandas as pd
-
+from variable_generators import generators
+import copy
 
 @orca.step()
 def elcm_simulate(jobs, buildings, aggregations, zones, elcm_config):
@@ -1036,3 +1037,86 @@ def price_vars(net):
     nodes = orca.get_table('nodes')
     nodes = nodes.to_frame().join(nodes2)
     orca.add_table("nodes", nodes)
+
+
+@orca.step()
+def generate_skims_vars():
+    """
+    This model step just aggregates a bunch of variables to
+    the zone level and lazily defines them as  new columns in the
+    zones table. Only columns used in creating skim-based 
+    accessibility variables are required to be generated here
+    so it might be useful in the future to clean this section up.
+    """
+    geographic_levels = [('parcels', 'parcel_id')]
+
+    aggregation_functions = ['mean', 'median', 'std', 'sum']
+
+    geographic_levels = {'zones': 'zone_id'}
+    geographic_levels['parcels'] = 'parcel_id'
+
+    variables_to_aggregate = {
+        'households': [
+            'persons', 'income',
+            # 'race_of_head', 'age_of_head',
+            # 'workers', 'children', 'cars',
+            # 'hispanic_head',
+            # 'tenure',
+            # 'recent_mover', 'income_quartile'
+        ],
+        'jobs': ['sector_id'],
+        # 'parcels': [
+        #     'acres', 'x', 'y', 'land_value', 'proportion_undevelopable'],
+        'buildings': [
+            # 'building_type_id',
+            'residential_units',
+            # 'non_residential_sqft',
+            # 'year_built',
+            # 'value_per_unit',
+            # 'sqft_per_unit',
+            # 'job_spaces'
+        ]
+    }
+    sum_vars = ['persons', 'residential_units', 'income']
+
+    for agent in variables_to_aggregate.keys():
+        for geography_name, geography_id in geographic_levels.items():
+            if geography_name != agent:
+
+                # Define size variables
+                generators.make_size_var(agent, geography_name, geography_id)
+
+                # Define attribute variables
+                variables = variables_to_aggregate[agent]
+                for var in variables:
+                    for aggregation_function in aggregation_functions:
+                        if aggregation_function == 'sum':
+                            if var in sum_vars:
+                                generators.make_agg_var(agent, geography_name,
+                                                        geography_id,
+                                                        var,
+                                                        aggregation_function)
+
+                        else:
+                            generators.make_agg_var(agent, geography_name,
+                                                    geography_id, var,
+                                                    aggregation_function)
+
+
+@orca.step()
+def skims_aggregations_drive():
+    # Calculate skim-based accessibility variables
+    variables_to_aggregate = [
+        'total_jobs', 'sum_residential_units', 'sum_persons', 'sum_income']
+    skim_access_vars = []
+
+    # drive skim variables
+    travel_times = [15, 45]  # 15 and 45 min travel times in s
+
+    for impedance in ['gen_tt_CAR']:
+        for time in travel_times:
+            for variable in variables_to_aggregate:
+                var_name = '_'.join([variable, impedance, str(time)])
+                skim_access_vars.append(var_name)
+                register_skim_access_variable(
+                    var_name, variable, impedance, time)

--- a/baus/ual.py
+++ b/baus/ual.py
@@ -445,8 +445,8 @@ def remove_old_units(buildings, units):
 
     print "Removing %d units from %d buildings that no longer exist" % \
         ((len(units2) - len(current_units)),
-         (len(units2.groupby('building_id')) -
-          len(current_units.groupby('building_id'))))
+         (len(units2['building_id'].unique()) -
+          len(current_units['building_id'].unique())))
 
     orca.add_table('units', current_units)
 

--- a/baus/variables.py
+++ b/baus/variables.py
@@ -969,8 +969,6 @@ def parcels_zoning_by_scenario(parcels, parcels_zoning_calculations,
     return df
 
 
-
-
 GROSS_AVE_UNIT_SIZE = 1000.0
 PARCEL_USE_EFFICIENCY = .8
 HEIGHT_PER_STORY = 12.0

--- a/configs/elcm.yaml
+++ b/configs/elcm.yaml
@@ -25,274 +25,274 @@ prediction_sample_size: null
 
 default_config:
     model_expression: np.log1p(non_residential_rent) + office_1500 + industrial_1500
-        + retail_1500 + np.log1p(total_jobs_45_gen_tt_min) + np.log1p(sum_income_45_gen_tt_min)
-        + np.log1p(sum_income_45_gen_tt_min) + residential_units_1500 + ave_income_1500
-        + juris_ave_income + embarcadero + stanford
+        + retail_1500 + np.log1p(total_jobs_gen_tt_CAR_45) + np.log1p(sum_income_gen_tt_CAR_45)
+        + residential_units_1500 + ave_income_1500 + juris_ave_income + embarcadero
+        + stanford
 
 models:
     AGREMPN:
         fit_parameters:
             Coefficient:
-                ave_income_1500: 0.13039482743560585
-                embarcadero: 0.023640456132384625
-                industrial_1500: 0.26686446348712894
-                juris_ave_income: 0.3683498029834974
-                np.log1p(non_residential_rent): 1.1803642880398346
-                np.log1p(sum_income_45_gen_tt_min): -0.08118915715065225
-                np.log1p(total_jobs_45_gen_tt_min): -0.07035706241990208
-                office_1500: -0.1492766723460449
-                residential_units_1500: -0.4378451493649907
-                retail_1500: -0.2560480307399762
-                stanford: 0.024562358916063017
+                ave_income_1500: 0.12533089235790004
+                embarcadero: 0.038248718372346696
+                industrial_1500: 0.2698006046275434
+                juris_ave_income: 0.2625598548731465
+                np.log1p(non_residential_rent): 1.1549270902656714
+                np.log1p(sum_income_gen_tt_CAR_45): 0.530878105146128
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.36412219921361
+                office_1500: -0.1624150458618462
+                residential_units_1500: -0.456776474872767
+                retail_1500: -0.2492327562866125
+                stanford: 0.03156190144187415
             Std. Error:
-                ave_income_1500: 0.007887136948082898
-                embarcadero: 0.0012520901807643724
-                industrial_1500: 0.008149996186259298
-                juris_ave_income: 0.026895112345463587
-                np.log1p(non_residential_rent): 0.016105973136830987
-                np.log1p(sum_income_45_gen_tt_min): 0.025501476761475104
-                np.log1p(total_jobs_45_gen_tt_min): 0.034948747579349515
-                office_1500: 0.009836200088492309
-                residential_units_1500: 0.01261085651827972
-                retail_1500: 0.011347411314499165
-                stanford: 0.0010098303616320244
+                ave_income_1500: 0.007767931817730633
+                embarcadero: 0.0016387337167195072
+                industrial_1500: 0.008338274027639194
+                juris_ave_income: 0.09781359501542786
+                np.log1p(non_residential_rent): 0.016148729317264764
+                np.log1p(sum_income_gen_tt_CAR_45): 0.085965611871089
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.09233381491132661
+                office_1500: 0.009739764842383538
+                residential_units_1500: 0.012792175204239392
+                retail_1500: 0.011508216007503343
+                stanford: 0.001157749316361733
             T-Score:
-                ave_income_1500: 16.532593296392616
-                embarcadero: 18.88079348881457
-                industrial_1500: 32.74412127174442
-                juris_ave_income: 13.695789712721805
-                np.log1p(non_residential_rent): 73.2873622731053
-                np.log1p(sum_income_45_gen_tt_min): -3.183704140354104
-                np.log1p(total_jobs_45_gen_tt_min): -2.0131497490764048
-                office_1500: -15.17625414317146
-                residential_units_1500: -34.719699548585325
-                retail_1500: -22.56444431628301
-                stanford: 24.32325254745448
+                ave_income_1500: 16.134396554798148
+                embarcadero: 23.340410941757362
+                industrial_1500: 32.356888695817034
+                juris_ave_income: 2.6842879543659923
+                np.log1p(non_residential_rent): 71.51814037968471
+                np.log1p(sum_income_gen_tt_CAR_45): 6.17547055841601
+                np.log1p(total_jobs_gen_tt_CAR_45): -3.9435411562199305
+                office_1500: -16.675458647120646
+                residential_units_1500: -35.7074905229088
+                retail_1500: -21.656941104000225
+                stanford: 27.261429564958423
         fitted: true
         log_likelihoods:
-            convergence: -8611.55782206392
+            convergence: -8723.774638105575
             'null': -19560.115027141746
-            ratio: 0.5597388967235384
+            ratio: 0.5540018744265867
         name: AGREMPN
     FPSEMPN:
         fit_parameters:
             Coefficient:
-                ave_income_1500: 0.05806195347582837
-                embarcadero: -0.013659830499923076
-                industrial_1500: 0.05240664192720411
-                juris_ave_income: 0.340780030575128
-                np.log1p(non_residential_rent): 1.0977484729624891
-                np.log1p(sum_income_45_gen_tt_min): 0.19873974181505094
-                np.log1p(total_jobs_45_gen_tt_min): -0.2653026432614493
-                office_1500: 0.3953420180320382
-                residential_units_1500: -0.3324863702786013
-                retail_1500: 0.04455207857329359
-                stanford: -0.0030345742910609487
+                ave_income_1500: 0.06216301908784339
+                embarcadero: -0.011240602049208364
+                industrial_1500: 0.04848656737399302
+                juris_ave_income: 0.33463059542521517
+                np.log1p(non_residential_rent): 1.080365008179614
+                np.log1p(sum_income_gen_tt_CAR_45): -1.4009585426407705
+                np.log1p(total_jobs_gen_tt_CAR_45): 1.3198188756296996
+                office_1500: 0.4437590474984166
+                residential_units_1500: -0.341265798946232
+                retail_1500: 0.041757119394906866
+                stanford: -0.0011688258154258747
             Std. Error:
-                ave_income_1500: 0.010275173945183293
-                embarcadero: 0.0016731984940213623
-                industrial_1500: 0.00797606226090091
-                juris_ave_income: 0.08042002956237236
-                np.log1p(non_residential_rent): 0.013470768692227483
-                np.log1p(sum_income_45_gen_tt_min): 0.07969377789795336
-                np.log1p(total_jobs_45_gen_tt_min): 0.09065497434373014
-                office_1500: 0.011743260048543305
-                residential_units_1500: 0.014586116303254492
-                retail_1500: 0.012772600838191902
-                stanford: 0.0011717828447645148
+                ave_income_1500: 0.010522603431512949
+                embarcadero: 0.0020511921257925893
+                industrial_1500: 0.008078534140989161
+                juris_ave_income: 0.0854935646040667
+                np.log1p(non_residential_rent): 0.013542852132378201
+                np.log1p(sum_income_gen_tt_CAR_45): 0.09592278953653917
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.127521647045386
+                office_1500: 0.011845812032767952
+                residential_units_1500: 0.015134270144173819
+                retail_1500: 0.012539211372184103
+                stanford: 0.001162860832817182
             T-Score:
-                ave_income_1500: 5.650702731222
-                embarcadero: -8.163903176301016
-                industrial_1500: 6.570490577048817
-                juris_ave_income: 4.237501931167844
-                np.log1p(non_residential_rent): 81.49115303240865
-                np.log1p(sum_income_45_gen_tt_min): 2.4937924522731763
-                np.log1p(total_jobs_45_gen_tt_min): -2.9265094958332876
-                office_1500: 33.665440124616715
-                residential_units_1500: -22.79471542431182
-                retail_1500: 3.488097619090742
-                stanford: -2.5897070473589214
+                ave_income_1500: 5.907570259815972
+                embarcadero: -5.480033736413135
+                industrial_1500: 6.001901647971023
+                juris_ave_income: 3.9141027394861685
+                np.log1p(non_residential_rent): 79.77381703789567
+                np.log1p(sum_income_gen_tt_CAR_45): -14.605064650534517
+                np.log1p(total_jobs_gen_tt_CAR_45): 10.3497634026007
+                office_1500: 37.46126025559816
+                residential_units_1500: -22.54920757296035
+                retail_1500: 3.33012325540163
+                stanford: -1.0051295756468483
         fitted: true
         log_likelihoods:
-            convergence: -8419.528245704889
+            convergence: -8190.791442884345
             'null': -19560.115027141746
-            ratio: 0.5695563019940376
+            ratio: 0.5812503437981449
         name: FPSEMPN
     HEREMPN:
         fit_parameters:
             Coefficient:
-                ave_income_1500: 0.016943902049421648
-                embarcadero: -0.009483738760869867
-                industrial_1500: -0.06800516288712725
-                juris_ave_income: -0.16904251070131324
-                np.log1p(non_residential_rent): 1.0795049999615458
-                np.log1p(sum_income_45_gen_tt_min): -0.020139081230671263
-                np.log1p(total_jobs_45_gen_tt_min): -0.13002804222816386
-                office_1500: 0.26711435052930355
-                residential_units_1500: -0.2175054494722987
-                retail_1500: 0.1462054018105564
-                stanford: -0.0018500200437681685
+                ave_income_1500: 0.014091094398020863
+                embarcadero: -0.010564597032144464
+                industrial_1500: -0.07949643769185641
+                juris_ave_income: -0.18056834156790275
+                np.log1p(non_residential_rent): 1.0950431398815017
+                np.log1p(sum_income_gen_tt_CAR_45): -1.4268145329122364
+                np.log1p(total_jobs_gen_tt_CAR_45): 1.2420632763099873
+                office_1500: 0.287448088592128
+                residential_units_1500: -0.23148947979661466
+                retail_1500: 0.1420632811920071
+                stanford: -0.0009415544973865862
             Std. Error:
-                ave_income_1500: 0.01133434872339039
-                embarcadero: 0.001489285067533715
-                industrial_1500: 0.007584812948938187
-                juris_ave_income: 0.054608906670847716
-                np.log1p(non_residential_rent): 0.011114410744312178
-                np.log1p(sum_income_45_gen_tt_min): 0.05597778960220763
-                np.log1p(total_jobs_45_gen_tt_min): 0.06960042202501691
-                office_1500: 0.010449387385846519
-                residential_units_1500: 0.014407897034105447
-                retail_1500: 0.011140600594459914
-                stanford: 0.0009974111738752863
+                ave_income_1500: 0.011199668466614052
+                embarcadero: 0.0018235671503364255
+                industrial_1500: 0.007686515204256534
+                juris_ave_income: 0.07260779669741535
+                np.log1p(non_residential_rent): 0.01110373547012492
+                np.log1p(sum_income_gen_tt_CAR_45): 0.08245125085519614
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.1084546922576877
+                office_1500: 0.010719488771303602
+                residential_units_1500: 0.0141982735729382
+                retail_1500: 0.011105914667620544
+                stanford: 0.0010615500123541638
             T-Score:
-                ave_income_1500: 1.4949162464407835
-                embarcadero: -6.3679808302752425
-                industrial_1500: -8.965964400829085
-                juris_ave_income: -3.095511721562345
-                np.log1p(non_residential_rent): 97.12660660071292
-                np.log1p(sum_income_45_gen_tt_min): -0.3597691401140467
-                np.log1p(total_jobs_45_gen_tt_min): -1.8682076695084846
-                office_1500: 25.562680439152295
-                residential_units_1500: -15.096266232152672
-                retail_1500: 13.123655279703915
-                stanford: -1.8548218550431943
+                ave_income_1500: 1.2581706717503365
+                embarcadero: -5.793368799276422
+                industrial_1500: -10.342324913093771
+                juris_ave_income: -2.486900164735759
+                np.log1p(non_residential_rent): 98.6193468700477
+                np.log1p(sum_income_gen_tt_CAR_45): -17.304947082222675
+                np.log1p(total_jobs_gen_tt_CAR_45): 11.452370113769282
+                office_1500: 26.81546617797999
+                residential_units_1500: -16.304058279158095
+                retail_1500: 12.791677718017649
+                stanford: -0.8869619767593733
         fitted: true
         log_likelihoods:
-            convergence: -11180.920652822124
+            convergence: -10942.249675107047
             'null': -19560.115027141746
-            ratio: 0.42838165126803174
+            ratio: 0.44058357223750944
         name: HEREMPN
     MWTEMPN:
         fit_parameters:
             Coefficient:
-                ave_income_1500: 0.08590979575065037
-                embarcadero: -0.002757944579793286
-                industrial_1500: 0.397760832183506
-                juris_ave_income: 0.4424161986632427
-                np.log1p(non_residential_rent): 1.2997991907185522
-                np.log1p(sum_income_45_gen_tt_min): -0.28366084634043087
-                np.log1p(total_jobs_45_gen_tt_min): 0.3805003344848524
-                office_1500: 0.032102940395610985
-                residential_units_1500: -0.3778420285042577
-                retail_1500: -0.15337269827313607
-                stanford: 0.0028448797852411193
+                ave_income_1500: 0.07649648759192579
+                embarcadero: -0.006446346600902632
+                industrial_1500: 0.38325448542026874
+                juris_ave_income: 0.39979664120387504
+                np.log1p(non_residential_rent): 1.2834741405199626
+                np.log1p(sum_income_gen_tt_CAR_45): -2.2124224984331207
+                np.log1p(total_jobs_gen_tt_CAR_45): 2.258980791275843
+                office_1500: 0.04521115033776392
+                residential_units_1500: -0.3860114143173964
+                retail_1500: -0.13763728734405484
+                stanford: 2.4755050600784955e-05
             Std. Error:
-                ave_income_1500: 0.008040976534161054
-                embarcadero: 0.0017277638364105912
-                industrial_1500: 0.008398878936900903
-                juris_ave_income: 0.08226860005694728
-                np.log1p(non_residential_rent): 0.019195885814022703
-                np.log1p(sum_income_45_gen_tt_min): 0.08095634043084617
-                np.log1p(total_jobs_45_gen_tt_min): 0.09365055934875026
-                office_1500: 0.01141600244290596
-                residential_units_1500: 0.012312589257425758
-                retail_1500: 0.011360102803614894
-                stanford: 0.0011845678173154808
+                ave_income_1500: 0.008229012247915798
+                embarcadero: 0.0022391953862776325
+                industrial_1500: 0.00879548929855738
+                juris_ave_income: 0.09535220830706986
+                np.log1p(non_residential_rent): 0.019191073197752432
+                np.log1p(sum_income_gen_tt_CAR_45): 0.09960672541156637
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.13205935311123362
+                office_1500: 0.011345652904492807
+                residential_units_1500: 0.012772511031995826
+                retail_1500: 0.011444035842225636
+                stanford: 0.0012247684098584898
             T-Score:
-                ave_income_1500: 10.684000305892408
-                embarcadero: -1.596250900541409
-                industrial_1500: 47.35880052228441
-                juris_ave_income: 5.377704231711699
-                np.log1p(non_residential_rent): 67.71238396141331
-                np.log1p(sum_income_45_gen_tt_min): -3.5038743701950956
-                np.log1p(total_jobs_45_gen_tt_min): 4.06297983835726
-                office_1500: 2.8120999935104374
-                residential_units_1500: -30.687454978357216
-                retail_1500: -13.500995626934943
-                stanford: 2.4016183317290434
+                ave_income_1500: 9.295950144113641
+                embarcadero: -2.8788674004990846
+                industrial_1500: 43.57398120911015
+                juris_ave_income: 4.192840924212053
+                np.log1p(non_residential_rent): 66.87870591157336
+                np.log1p(sum_income_gen_tt_CAR_45): -22.211577474227592
+                np.log1p(total_jobs_gen_tt_CAR_45): 17.105799309596062
+                office_1500: 3.9848874911253978
+                residential_units_1500: -30.222045872610096
+                retail_1500: -12.026988489166348
+                stanford: 0.020212025719740078
         fitted: true
         log_likelihoods:
-            convergence: -6237.124161379928
+            convergence: -6251.862363825029
             'null': -19560.115027141746
-            ratio: 0.6811304967928229
+            ratio: 0.6803770143912802
         name: MWTEMPN
     OTHEMPN:
         fit_parameters:
             Coefficient:
-                ave_income_1500: 0.029062805143819558
-                embarcadero: -0.009424173509434718
-                industrial_1500: 0.10804407677332749
-                juris_ave_income: -0.15561083756297178
-                np.log1p(non_residential_rent): 1.154920705009005
-                np.log1p(sum_income_45_gen_tt_min): 0.10586539522368982
-                np.log1p(total_jobs_45_gen_tt_min): -0.26662185732984206
-                office_1500: 0.2513317290477359
-                residential_units_1500: -0.23703252818652923
-                retail_1500: -0.008307042356247686
-                stanford: -0.0037668069541404487
+                ave_income_1500: 0.034822941611578784
+                embarcadero: -0.01685079387347939
+                industrial_1500: 0.1029079104713944
+                juris_ave_income: -0.08562307699604677
+                np.log1p(non_residential_rent): 1.1526517135679069
+                np.log1p(sum_income_gen_tt_CAR_45): -1.7155416416553089
+                np.log1p(total_jobs_gen_tt_CAR_45): 1.3282301273920627
+                office_1500: 0.2251515985275978
+                residential_units_1500: -0.24519546785691226
+                retail_1500: 0.021302905418564257
+                stanford: -0.006694481970240738
             Std. Error:
-                ave_income_1500: 0.009751265482189162
-                embarcadero: 0.0014282605951761462
-                industrial_1500: 0.007508493820892321
-                juris_ave_income: 0.07551191136245562
-                np.log1p(non_residential_rent): 0.012854396142625912
-                np.log1p(sum_income_45_gen_tt_min): 0.07322030450367184
-                np.log1p(total_jobs_45_gen_tt_min): 0.08177754945152259
-                office_1500: 0.010811394145334219
-                residential_units_1500: 0.013872347669185131
-                retail_1500: 0.011746632673195987
-                stanford: 0.0010190109400618967
+                ave_income_1500: 0.009512852244356754
+                embarcadero: 0.0018589804768220995
+                industrial_1500: 0.0073617898620952004
+                juris_ave_income: 0.07941655725081669
+                np.log1p(non_residential_rent): 0.012858848398802757
+                np.log1p(sum_income_gen_tt_CAR_45): 0.08587707121058119
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.11240075702758384
+                office_1500: 0.010725755092117562
+                residential_units_1500: 0.013187068447476597
+                retail_1500: 0.012063554938555212
+                stanford: 0.0010650053343390078
             T-Score:
-                ave_income_1500: 2.9804136906028478
-                embarcadero: -6.598357149433533
-                industrial_1500: 14.38958056710332
-                juris_ave_income: -2.060745579807177
-                np.log1p(non_residential_rent): 89.84636012416188
-                np.log1p(sum_income_45_gen_tt_min): 1.4458475137641758
-                np.log1p(total_jobs_45_gen_tt_min): -3.26033072790833
-                office_1500: 23.246930568727898
-                residential_units_1500: -17.086691729407374
-                retail_1500: -0.7071849939773023
-                stanford: -3.6965323982798903
+                ave_income_1500: 3.6606204655640022
+                embarcadero: -9.064535149011128
+                industrial_1500: 13.97865361537314
+                juris_ave_income: -1.0781514580848472
+                np.log1p(non_residential_rent): 89.63879795606162
+                np.log1p(sum_income_gen_tt_CAR_45): -19.97671342853075
+                np.log1p(total_jobs_gen_tt_CAR_45): 11.816914427596842
+                office_1500: 20.991678123721417
+                residential_units_1500: -18.59362972396124
+                retail_1500: 1.7658895348070254
+                stanford: -6.2858670791500275
         fitted: true
         log_likelihoods:
-            convergence: -9603.151144413103
+            convergence: -9616.876469182042
             'null': -19560.115027141746
-            ratio: 0.5090442397149656
+            ratio: 0.5083425401211803
         name: OTHEMPN
     RETEMPN:
         fit_parameters:
             Coefficient:
-                ave_income_1500: 0.06393807507686547
-                embarcadero: -0.011838074829522096
-                industrial_1500: 0.04530607097640789
-                juris_ave_income: -0.0635133354783626
-                np.log1p(non_residential_rent): 1.396943945344294
-                np.log1p(sum_income_45_gen_tt_min): -0.18642694612767208
-                np.log1p(total_jobs_45_gen_tt_min): 0.18112068904720774
-                office_1500: -0.062189018395103844
-                residential_units_1500: -0.3431578676474434
-                retail_1500: 0.352022607906478
-                stanford: -0.0009762098073599988
+                ave_income_1500: 0.06818548620032203
+                embarcadero: -0.026440095744658547
+                industrial_1500: 0.031141559388792203
+                juris_ave_income: 0.03883130759528736
+                np.log1p(non_residential_rent): 1.3705835752822784
+                np.log1p(sum_income_gen_tt_CAR_45): -1.8624528876540807
+                np.log1p(total_jobs_gen_tt_CAR_45): 1.4553512584826158
+                office_1500: -0.0759219776841913
+                residential_units_1500: -0.36551919288750084
+                retail_1500: 0.3723697287578536
+                stanford: -0.008427373057788247
             Std. Error:
-                ave_income_1500: 0.009769700799468265
-                embarcadero: 0.001597893880260075
-                industrial_1500: 0.007590645156678358
-                juris_ave_income: 0.06243633560491405
-                np.log1p(non_residential_rent): 0.015423944236194847
-                np.log1p(sum_income_45_gen_tt_min): 0.06288463078742206
-                np.log1p(total_jobs_45_gen_tt_min): 0.0781160489446114
-                office_1500: 0.01103781589766261
-                residential_units_1500: 0.013643753132874286
-                retail_1500: 0.011958144016282327
-                stanford: 0.0010823297783404313
+                ave_income_1500: 0.010292484699350339
+                embarcadero: 0.0020181000546903344
+                industrial_1500: 0.007547129607160711
+                juris_ave_income: 0.08147303329272315
+                np.log1p(non_residential_rent): 0.015314790232225048
+                np.log1p(sum_income_gen_tt_CAR_45): 0.08606402298177303
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.11517136072162781
+                office_1500: 0.011295458302491805
+                residential_units_1500: 0.013616375723311204
+                retail_1500: 0.012188991571062098
+                stanford: 0.0010891771067476905
             T-Score:
-                ave_income_1500: 6.544527451684644
-                embarcadero: -7.408548825279509
-                industrial_1500: 5.968671969410527
-                juris_ave_income: -1.0172495689090983
-                np.log1p(non_residential_rent): 90.56982597655748
-                np.log1p(sum_income_45_gen_tt_min): -2.964586796380786
-                np.log1p(total_jobs_45_gen_tt_min): 2.318610471141882
-                office_1500: -5.634177900020339
-                residential_units_1500: -25.151280905296723
-                retail_1500: 29.43789666917881
-                stanford: -0.9019522763725956
+                ave_income_1500: 6.624783829372697
+                embarcadero: -13.101479127959106
+                industrial_1500: 4.126278599912358
+                juris_ave_income: 0.4766154643558069
+                np.log1p(non_residential_rent): 89.49411350070771
+                np.log1p(sum_income_gen_tt_CAR_45): -21.64031872003611
+                np.log1p(total_jobs_gen_tt_CAR_45): 12.636398922126464
+                office_1500: -6.721460577428959
+                residential_units_1500: -26.844088347366387
+                retail_1500: 30.549674810006195
+                stanford: -7.737376231632878
         fitted: true
         log_likelihoods:
-            convergence: -7663.4080937652425
+            convergence: -7825.986201686207
             'null': -19560.115027141746
-            ratio: 0.6082125241527749
+            ratio: 0.599900808823117
         name: RETEMPN
 
 fitted: true

--- a/configs/hlcm_owner.yaml
+++ b/configs/hlcm_owner.yaml
@@ -23,7 +23,7 @@ estimation_sample_size: 6000
 prediction_sample_size: null
 
 default_config:
-    model_expression: np.log1p(total_jobs_45_gen_tt_min) + np.log1p(sum_income_45_gen_tt_min)
+    model_expression: np.log1p(total_jobs_gen_tt_CAR_45) + np.log1p(sum_income_gen_tt_CAR_45)
         + juris_ave_income + jobs_1500 + residential_units_1500 + np.log1p(unit_residential_price)
         + np.log1p(sqft_per_unit) + sfdu
 
@@ -31,282 +31,282 @@ models:
     1:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.028320011860910512
-                juris_ave_income: -0.39574100401202816
-                np.log1p(sqft_per_unit): -0.11256493784821853
-                np.log1p(sum_income_45_gen_tt_min): 0.14348845938975854
-                np.log1p(total_jobs_45_gen_tt_min): -0.19140546018811924
-                np.log1p(unit_residential_price): -0.23107546664791145
-                residential_units_1500: -0.2526936625076566
-                sfdu: 0.2341241870993695
+                jobs_1500: -0.025661128404660047
+                juris_ave_income: -0.3718767374861433
+                np.log1p(sqft_per_unit): -0.10467276266454029
+                np.log1p(sum_income_gen_tt_CAR_45): 0.6323676015617451
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.6142636662849019
+                np.log1p(unit_residential_price): -0.3222504366819485
+                residential_units_1500: -0.27303175079887676
+                sfdu: 0.21729397499265712
             Std. Error:
-                jobs_1500: 0.01325127102832193
-                juris_ave_income: 0.047847539681498893
-                np.log1p(sqft_per_unit): 0.030912547122984805
-                np.log1p(sum_income_45_gen_tt_min): 0.03408456149003405
-                np.log1p(total_jobs_45_gen_tt_min): 0.035859601489551744
-                np.log1p(unit_residential_price): 0.039557764566539935
-                residential_units_1500: 0.026667239217094855
-                sfdu: 0.01718556308824958
+                jobs_1500: 0.012710757608270621
+                juris_ave_income: 0.060266521384063854
+                np.log1p(sqft_per_unit): 0.030826899992204455
+                np.log1p(sum_income_gen_tt_CAR_45): 0.04987920460032072
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.052479237690429774
+                np.log1p(unit_residential_price): 0.03897814905111187
+                residential_units_1500: 0.026255810102845917
+                sfdu: 0.01657969618993065
             T-Score:
-                jobs_1500: -2.137154375635528
-                juris_ave_income: -8.27087467080462
-                np.log1p(sqft_per_unit): -3.6413996362183196
-                np.log1p(sum_income_45_gen_tt_min): 4.2097786539431645
-                np.log1p(total_jobs_45_gen_tt_min): -5.337634893792342
-                np.log1p(unit_residential_price): -5.841469283715981
-                residential_units_1500: -9.47580889234567
-                sfdu: 13.623306137664414
+                jobs_1500: -2.018851212138834
+                juris_ave_income: -6.170535961686978
+                np.log1p(sqft_per_unit): -3.3955007701393933
+                np.log1p(sum_income_gen_tt_CAR_45): 12.677980866552932
+                np.log1p(total_jobs_gen_tt_CAR_45): -11.704889272751771
+                np.log1p(unit_residential_price): -8.267463810541209
+                residential_units_1500: -10.39890788855463
+                sfdu: 13.106028753688884
         fitted: true
         log_likelihoods:
-            convergence: -21509.222969873816
-            'null': -21864.296577339213
-            ratio: 0.016239882504768377
+            convergence: -21423.605729522973
+            'null': -21782.144094225212
+            ratio: 0.016460196165780316
         name: 1
     2:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.03442025407417646
-                juris_ave_income: -0.4853061539089772
-                np.log1p(sqft_per_unit): -0.13440441235881373
-                np.log1p(sum_income_45_gen_tt_min): 0.035517848260062615
-                np.log1p(total_jobs_45_gen_tt_min): -0.064946323493494
-                np.log1p(unit_residential_price): -0.1880850881593235
-                residential_units_1500: -0.32146816411782675
-                sfdu: 0.2776741375215419
+                jobs_1500: -0.02668399705172651
+                juris_ave_income: -0.4556418332722915
+                np.log1p(sqft_per_unit): -0.13438373649201218
+                np.log1p(sum_income_gen_tt_CAR_45): -0.25914937822770445
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.2095404421367441
+                np.log1p(unit_residential_price): -0.22401173490625007
+                residential_units_1500: -0.3375839997807816
+                sfdu: 0.2725655293440662
             Std. Error:
-                jobs_1500: 0.013281334954704708
-                juris_ave_income: 0.04816363915446928
-                np.log1p(sqft_per_unit): 0.030908311212484375
-                np.log1p(sum_income_45_gen_tt_min): 0.035002095463818064
-                np.log1p(total_jobs_45_gen_tt_min): 0.0364638740602394
-                np.log1p(unit_residential_price): 0.03999987960382763
-                residential_units_1500: 0.026691806793877445
-                sfdu: 0.017434312016519845
+                jobs_1500: 0.013170064606889808
+                juris_ave_income: 0.060997406717743695
+                np.log1p(sqft_per_unit): 0.031538106825414434
+                np.log1p(sum_income_gen_tt_CAR_45): 0.050850567842768465
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.05333407633883874
+                np.log1p(unit_residential_price): 0.03992674922032543
+                residential_units_1500: 0.026802378200897755
+                sfdu: 0.017580737737890102
             T-Score:
-                jobs_1500: -2.5916260821344332
-                juris_ave_income: -10.076193627157508
-                np.log1p(sqft_per_unit): -4.348487739586548
-                np.log1p(sum_income_45_gen_tt_min): 1.0147349119934173
-                np.log1p(total_jobs_45_gen_tt_min): -1.7811141895181173
-                np.log1p(unit_residential_price): -4.702141356978621
-                residential_units_1500: -12.043701897001778
-                sfdu: 15.92687668193803
+                jobs_1500: -2.0261098064596434
+                juris_ave_income: -7.469855815030062
+                np.log1p(sqft_per_unit): -4.26099566584388
+                np.log1p(sum_income_gen_tt_CAR_45): -5.09629271061441
+                np.log1p(total_jobs_gen_tt_CAR_45): 3.92882855616557
+                np.log1p(unit_residential_price): -5.610567834363356
+                residential_units_1500: -12.595300209944583
+                sfdu: 15.50364571770111
         fitted: true
         log_likelihoods:
-            convergence: -21477.172092590175
-            'null': -21883.856692366357
-            ratio: 0.018583771841187535
+            convergence: -21449.433945270986
+            'null': -21876.0326463555
+            ratio: 0.019500734341589276
         name: 2
     3:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.04945627150709449
-                juris_ave_income: -0.46592760799334176
-                np.log1p(sqft_per_unit): -0.13782590869139572
-                np.log1p(sum_income_45_gen_tt_min): 0.21163072108773423
-                np.log1p(total_jobs_45_gen_tt_min): -0.21947459256329457
-                np.log1p(unit_residential_price): -0.36007756595136753
-                residential_units_1500: -0.3470959067667378
-                sfdu: 0.33835911430549814
+                jobs_1500: -0.03932954662054984
+                juris_ave_income: -0.3959042287941393
+                np.log1p(sqft_per_unit): -0.08382162142702539
+                np.log1p(sum_income_gen_tt_CAR_45): 0.008194477714081374
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.039384502034744605
+                np.log1p(unit_residential_price): -0.3347743170017982
+                residential_units_1500: -0.3457280494570587
+                sfdu: 0.3000351956771397
             Std. Error:
-                jobs_1500: 0.013245431694327429
-                juris_ave_income: 0.04719770022963273
-                np.log1p(sqft_per_unit): 0.030537459053662667
-                np.log1p(sum_income_45_gen_tt_min): 0.033981539805623524
-                np.log1p(total_jobs_45_gen_tt_min): 0.035286395770870664
-                np.log1p(unit_residential_price): 0.04014640193723888
-                residential_units_1500: 0.02716936798760001
-                sfdu: 0.01814801304748244
+                jobs_1500: 0.013123481955980112
+                juris_ave_income: 0.060912100740924416
+                np.log1p(sqft_per_unit): 0.03116253131256224
+                np.log1p(sum_income_gen_tt_CAR_45): 0.0508563928916222
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.052442265965032465
+                np.log1p(unit_residential_price): 0.040053177263109675
+                residential_units_1500: 0.02727567747140804
+                sfdu: 0.017925301772003716
             T-Score:
-                jobs_1500: -3.733836136747052
-                juris_ave_income: -9.871828621446529
-                np.log1p(sqft_per_unit): -4.513339123900187
-                np.log1p(sum_income_45_gen_tt_min): 6.227814345620441
-                np.log1p(total_jobs_45_gen_tt_min): -6.219807599178872
-                np.log1p(unit_residential_price): -8.969111765340243
-                residential_units_1500: -12.775266135198692
-                sfdu: 18.644416522085134
+                jobs_1500: -2.996883506410289
+                juris_ave_income: -6.499598995576046
+                np.log1p(sqft_per_unit): -2.689820688386608
+                np.log1p(sum_income_gen_tt_CAR_45): 0.16112974688441356
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.751006870317264
+                np.log1p(unit_residential_price): -8.3582462086007
+                residential_units_1500: -12.67532400687283
+                sfdu: 16.73808338031686
         fitted: true
         log_likelihoods:
-            convergence: -21545.989668368904
-            'null': -22106.84200367579
-            ratio: 0.02537007932718882
+            convergence: -21367.152938720996
+            'null': -21872.12062335007
+            ratio: 0.02308727595850879
         name: 3
     4:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.07653285239641537
-                juris_ave_income: -0.3625420573116623
-                np.log1p(sqft_per_unit): -0.08156203945172275
-                np.log1p(sum_income_45_gen_tt_min): 0.08394222333241835
-                np.log1p(total_jobs_45_gen_tt_min): -0.09375912223569956
-                np.log1p(unit_residential_price): -0.2568616687719334
-                residential_units_1500: -0.3420456852818172
-                sfdu: 0.3598322322073558
+                jobs_1500: -0.03791281243757438
+                juris_ave_income: -0.5694407811479795
+                np.log1p(sqft_per_unit): -0.027919074863948946
+                np.log1p(sum_income_gen_tt_CAR_45): -0.2500631030128107
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.20674038118260385
+                np.log1p(unit_residential_price): -0.03914364207490744
+                residential_units_1500: -0.4315118431569271
+                sfdu: 0.4054656283031076
             Std. Error:
-                jobs_1500: 0.0127550383816811
-                juris_ave_income: 0.04683611750702859
-                np.log1p(sqft_per_unit): 0.03097642100903412
-                np.log1p(sum_income_45_gen_tt_min): 0.034367192497314264
-                np.log1p(total_jobs_45_gen_tt_min): 0.03573841291036017
-                np.log1p(unit_residential_price): 0.03988738826730145
-                residential_units_1500: 0.02834395822341272
-                sfdu: 0.01897088747357973
+                jobs_1500: 0.013180895980963931
+                juris_ave_income: 0.059959649770351994
+                np.log1p(sqft_per_unit): 0.03135764725609639
+                np.log1p(sum_income_gen_tt_CAR_45): 0.05059104601937902
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.05345691187809226
+                np.log1p(unit_residential_price): 0.041264968506452566
+                residential_units_1500: 0.028676658434887994
+                sfdu: 0.01960300888572718
             T-Score:
-                jobs_1500: -6.000205574162171
-                juris_ave_income: -7.740651373531472
-                np.log1p(sqft_per_unit): -2.633036251280791
-                np.log1p(sum_income_45_gen_tt_min): 2.4425103487571262
-                np.log1p(total_jobs_45_gen_tt_min): -2.6234830984483875
-                np.log1p(unit_residential_price): -6.439671282827542
-                residential_units_1500: -12.067675325575385
-                sfdu: 18.96760142130857
+                jobs_1500: -2.8763456211420446
+                juris_ave_income: -9.49706649937019
+                np.log1p(sqft_per_unit): -0.8903434188137653
+                np.log1p(sum_income_gen_tt_CAR_45): -4.9428332222469455
+                np.log1p(total_jobs_gen_tt_CAR_45): 3.867420954919214
+                np.log1p(unit_residential_price): -0.948592559056154
+                residential_units_1500: -15.047493909958149
+                sfdu: 20.683846580221896
         fitted: true
         log_likelihoods:
-            convergence: -21655.233115181385
-            'null': -22181.170440778933
-            ratio: 0.02371098166355723
+            convergence: -21540.898473460253
+            'null': -22044.24963558893
+            ratio: 0.022833671839573633
         name: 4
     5:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.0507332338260717
-                juris_ave_income: -0.16719649751113677
-                np.log1p(sqft_per_unit): -0.08540593221359205
-                np.log1p(sum_income_45_gen_tt_min): 0.10709689128271387
-                np.log1p(total_jobs_45_gen_tt_min): -0.04099672819784358
-                np.log1p(unit_residential_price): -0.06484745924996643
-                residential_units_1500: -0.44509300765995297
-                sfdu: 0.3872653763341559
+                jobs_1500: -0.0482965705945169
+                juris_ave_income: -0.2690351198054159
+                np.log1p(sqft_per_unit): -0.03825534689524476
+                np.log1p(sum_income_gen_tt_CAR_45): -0.46195785560490393
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.4818326618566131
+                np.log1p(unit_residential_price): -0.17043826784143598
+                residential_units_1500: -0.37145761450690523
+                sfdu: 0.36029909009653777
             Std. Error:
-                jobs_1500: 0.013234577728927084
-                juris_ave_income: 0.055327084056205886
-                np.log1p(sqft_per_unit): 0.03096983423851044
-                np.log1p(sum_income_45_gen_tt_min): 0.04429814900784044
-                np.log1p(total_jobs_45_gen_tt_min): 0.04147333769455998
-                np.log1p(unit_residential_price): 0.038217650143755985
-                residential_units_1500: 0.028796721122518954
-                sfdu: 0.019728851279674407
+                jobs_1500: 0.013120514333688224
+                juris_ave_income: 0.05771847343010605
+                np.log1p(sqft_per_unit): 0.030996406541814847
+                np.log1p(sum_income_gen_tt_CAR_45): 0.05073382814444342
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.053985098447639046
+                np.log1p(unit_residential_price): 0.03892527285211828
+                residential_units_1500: 0.028338126904878882
+                sfdu: 0.019472811157769717
             T-Score:
-                jobs_1500: -3.8333851570634585
-                juris_ave_income: -3.021964745897047
-                np.log1p(sqft_per_unit): -2.7577135723700867
-                np.log1p(sum_income_45_gen_tt_min): 2.41763806572953
-                np.log1p(total_jobs_45_gen_tt_min): -0.9885080506366162
-                np.log1p(unit_residential_price): -1.696793471237562
-                residential_units_1500: -15.456378028812853
-                sfdu: 19.62939305711808
+                jobs_1500: -3.680996748009387
+                juris_ave_income: -4.661161389363544
+                np.log1p(sqft_per_unit): -1.2341865126732494
+                np.log1p(sum_income_gen_tt_CAR_45): -9.105519384219768
+                np.log1p(total_jobs_gen_tt_CAR_45): 8.92529004691822
+                np.log1p(unit_residential_price): -4.378601750306315
+                residential_units_1500: -13.108051063281554
+                sfdu: 18.502674687151025
         fitted: true
         log_likelihoods:
-            convergence: -21741.282796012903
-            'null': -22177.258417773504
-            ratio: 0.01965867978573932
+            convergence: -21662.824880142256
+            'null': -22087.281888648646
+            ratio: 0.01921725863083823
         name: 5
     6:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.07528446015747292
-                juris_ave_income: -0.008856559829650083
-                np.log1p(sqft_per_unit): 0.08336598420806787
-                np.log1p(sum_income_45_gen_tt_min): 0.18947242042903764
-                np.log1p(total_jobs_45_gen_tt_min): -0.15719940706270405
-                np.log1p(unit_residential_price): 0.10525467535145601
-                residential_units_1500: -0.39316654529402295
-                sfdu: 0.4016414712112917
+                jobs_1500: -0.05205712006927544
+                juris_ave_income: 0.07140705782817704
+                np.log1p(sqft_per_unit): 0.051365395341854844
+                np.log1p(sum_income_gen_tt_CAR_45): -0.513766796448777
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.5329537597720269
+                np.log1p(unit_residential_price): 0.061534040542412474
+                residential_units_1500: -0.41590865206005373
+                sfdu: 0.3822067597296367
             Std. Error:
-                jobs_1500: 0.013124703952126015
-                juris_ave_income: 0.05396290477886356
-                np.log1p(sqft_per_unit): 0.03120055223835443
-                np.log1p(sum_income_45_gen_tt_min): 0.04323374946805401
-                np.log1p(total_jobs_45_gen_tt_min): 0.04064961491884539
-                np.log1p(unit_residential_price): 0.03808028087643173
-                residential_units_1500: 0.02901558018517521
-                sfdu: 0.020415555173014664
+                jobs_1500: 0.013283960219908781
+                juris_ave_income: 0.05877497872673302
+                np.log1p(sqft_per_unit): 0.03085877369781468
+                np.log1p(sum_income_gen_tt_CAR_45): 0.05087450328895253
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.0537101166792999
+                np.log1p(unit_residential_price): 0.038423432166864224
+                residential_units_1500: 0.02866245946103441
+                sfdu: 0.019854222740684196
             T-Score:
-                jobs_1500: -5.7360882525108625
-                juris_ave_income: -0.16412311134739102
-                np.log1p(sqft_per_unit): 2.6719393801494054
-                np.log1p(sum_income_45_gen_tt_min): 4.382511874641854
-                np.log1p(total_jobs_45_gen_tt_min): -3.8671807193387586
-                np.log1p(unit_residential_price): 2.764020457018194
-                residential_units_1500: -13.550187271281986
-                sfdu: 19.673306349375327
+                jobs_1500: -3.918795239333599
+                juris_ave_income: 1.2149227337057034
+                np.log1p(sqft_per_unit): 1.6645313208117656
+                np.log1p(sum_income_gen_tt_CAR_45): -10.09870884695875
+                np.log1p(total_jobs_gen_tt_CAR_45): 9.922781641943992
+                np.log1p(unit_residential_price): 1.60147173410184
+                residential_units_1500: -14.510570965672597
+                sfdu: 19.25065336083086
         fitted: true
         log_likelihoods:
-            convergence: -21695.71204097696
-            'null': -22161.61032575179
-            ratio: 0.021022763144312506
+            convergence: -21577.211195124204
+            'null': -22020.77749755636
+            ratio: 0.02014308089173411
         name: 6
     7:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.07280761857063864
-                juris_ave_income: 0.48828514199262385
-                np.log1p(sqft_per_unit): 0.31383242626165875
-                np.log1p(sum_income_45_gen_tt_min): -0.20720770172891034
-                np.log1p(total_jobs_45_gen_tt_min): 0.30671408231335856
-                np.log1p(unit_residential_price): 0.45191336087746975
-                residential_units_1500: -0.4169030428184143
-                sfdu: 0.3488184701317115
+                jobs_1500: -0.063197017919658
+                juris_ave_income: 0.45231362340727654
+                np.log1p(sqft_per_unit): 0.3444284677330499
+                np.log1p(sum_income_gen_tt_CAR_45): -0.5188839239352624
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.614108099214781
+                np.log1p(unit_residential_price): 0.4058767177093224
+                residential_units_1500: -0.4109328009304792
+                sfdu: 0.37056882022747684
             Std. Error:
-                jobs_1500: 0.013419256255685097
-                juris_ave_income: 0.04295600807716047
-                np.log1p(sqft_per_unit): 0.030131508387157106
-                np.log1p(sum_income_45_gen_tt_min): 0.034454739067827825
-                np.log1p(total_jobs_45_gen_tt_min): 0.03811806920168078
-                np.log1p(unit_residential_price): 0.035384809530586314
-                residential_units_1500: 0.027191981232964686
-                sfdu: 0.01851174092925666
+                jobs_1500: 0.013335529835194539
+                juris_ave_income: 0.056241447331067236
+                np.log1p(sqft_per_unit): 0.030892762598288936
+                np.log1p(sum_income_gen_tt_CAR_45): 0.05085043542788211
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.056340940683133126
+                np.log1p(unit_residential_price): 0.035491846767431
+                residential_units_1500: 0.02781302603042522
+                sfdu: 0.019361968769376344
             T-Score:
-                jobs_1500: -5.425607588333633
-                juris_ave_income: 11.367097732068894
-                np.log1p(sqft_per_unit): 10.415423689688994
-                np.log1p(sum_income_45_gen_tt_min): -6.0139100551886315
-                np.log1p(total_jobs_45_gen_tt_min): 8.046422306716266
-                np.log1p(unit_residential_price): 12.771394473293402
-                residential_units_1500: -15.33183769312863
-                sfdu: 18.843093767611318
+                jobs_1500: -4.738995653016443
+                juris_ave_income: 8.042353902180302
+                np.log1p(sqft_per_unit): 11.149163712284082
+                np.log1p(sum_income_gen_tt_CAR_45): -10.204119582636848
+                np.log1p(total_jobs_gen_tt_CAR_45): 10.899855269875314
+                np.log1p(unit_residential_price): 11.435773414917763
+                residential_units_1500: -14.774832500460455
+                sfdu: 19.139005162201435
         fitted: true
         log_likelihoods:
-            convergence: -21415.596835799955
-            'null': -22196.818532800648
-            ratio: 0.03519521033369111
+            convergence: -21554.502529248894
+            'null': -22310.267199958078
+            ratio: 0.03387519584304233
         name: 7
     8:
         fit_parameters:
             Coefficient:
-                jobs_1500: -0.04658787560406789
-                juris_ave_income: 0.9655034490572729
-                np.log1p(sqft_per_unit): 0.42870810681525207
-                np.log1p(sum_income_45_gen_tt_min): -0.0028954638762218165
-                np.log1p(total_jobs_45_gen_tt_min): 0.12073526425317528
-                np.log1p(unit_residential_price): 0.7612980815721163
-                residential_units_1500: -0.40912284919113223
-                sfdu: 0.3310101188238813
+                jobs_1500: -0.022261484675476746
+                juris_ave_income: 1.0513791668669825
+                np.log1p(sqft_per_unit): 0.3918765903287963
+                np.log1p(sum_income_gen_tt_CAR_45): 0.6560641281762126
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.4076203170163265
+                np.log1p(unit_residential_price): 0.6788610975484278
+                residential_units_1500: -0.4347074583205045
+                sfdu: 0.29229557566823966
             Std. Error:
-                jobs_1500: 0.013598790728020439
-                juris_ave_income: 0.049357348279728284
-                np.log1p(sqft_per_unit): 0.031018512285670055
-                np.log1p(sum_income_45_gen_tt_min): 0.04264345649929549
-                np.log1p(total_jobs_45_gen_tt_min): 0.04272069778327283
-                np.log1p(unit_residential_price): 0.03363355694256855
-                residential_units_1500: 0.027759937973450374
-                sfdu: 0.018635099616297914
+                jobs_1500: 0.013473239715533469
+                juris_ave_income: 0.05231367045288706
+                np.log1p(sqft_per_unit): 0.03080833297034377
+                np.log1p(sum_income_gen_tt_CAR_45): 0.05034555875795593
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.06019269287204281
+                np.log1p(unit_residential_price): 0.033462244374299045
+                residential_units_1500: 0.02665970217865729
+                sfdu: 0.018411924974304755
             T-Score:
-                jobs_1500: -3.4258837080324445
-                juris_ave_income: 19.561493530514845
-                np.log1p(sqft_per_unit): 13.821040250641124
-                np.log1p(sum_income_45_gen_tt_min): -0.06789937106223208
-                np.log1p(total_jobs_45_gen_tt_min): 2.8261538438739837
-                np.log1p(unit_residential_price): 22.63507493043574
-                residential_units_1500: -14.737887728078414
-                sfdu: 17.762723336041947
+                jobs_1500: -1.6522740740529687
+                juris_ave_income: 20.09759892137256
+                np.log1p(sqft_per_unit): 12.719824558700346
+                np.log1p(sum_income_gen_tt_CAR_45): 13.03122150913733
+                np.log1p(total_jobs_gen_tt_CAR_45): -6.77192359349735
+                np.log1p(unit_residential_price): 20.287374927840546
+                residential_units_1500: -16.30578824201998
+                sfdu: 15.875340360997583
         fitted: true
         log_likelihoods:
-            convergence: -21064.85839882193
-            'null': -22341.563384001507
-            ratio: 0.05714483643046253
+            convergence: -21040.97759415934
+            'null': -22404.155752088365
+            ratio: 0.06084487953990225
         name: 8
 
 fitted: true

--- a/configs/hlcm_renter.yaml
+++ b/configs/hlcm_renter.yaml
@@ -23,7 +23,7 @@ estimation_sample_size: 6000
 prediction_sample_size: null
 
 default_config:
-    model_expression: np.log1p(total_jobs_45_gen_tt_min) + np.log1p(sum_income_45_gen_tt_min)
+    model_expression: np.log1p(total_jobs_gen_tt_CAR_45) + np.log1p(sum_income_gen_tt_CAR_45)
         + jobs_1500 + residential_units_1500 + np.log1p(unit_residential_rent) + np.log1p(sqft_per_unit)
         + sfdu
 
@@ -31,258 +31,258 @@ models:
     1:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.16701471831938075
-                np.log1p(sqft_per_unit): -0.11255913937897781
-                np.log1p(sum_income_45_gen_tt_min): -0.03474271058415278
-                np.log1p(total_jobs_45_gen_tt_min): -0.10544473469069021
-                np.log1p(unit_residential_rent): 0.4167177340838527
-                residential_units_1500: 0.1963482547633711
-                sfdu: -0.0820153935771806
+                jobs_1500: 0.16919551312693257
+                np.log1p(sqft_per_unit): -0.2302670913603859
+                np.log1p(sum_income_gen_tt_CAR_45): -0.3176181433090401
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.12200901995255878
+                np.log1p(unit_residential_rent): -0.09390600780801645
+                residential_units_1500: 0.22038736308891557
+                sfdu: -0.10245403568373206
             Std. Error:
-                jobs_1500: 0.014484936304018795
-                np.log1p(sqft_per_unit): 0.044628496308438174
-                np.log1p(sum_income_45_gen_tt_min): 0.03818489548758323
-                np.log1p(total_jobs_45_gen_tt_min): 0.04714710813558746
-                np.log1p(unit_residential_rent): 0.10939229331641606
-                residential_units_1500: 0.02509829362875742
-                sfdu: 0.013505033289379692
+                jobs_1500: 0.014474190475096219
+                np.log1p(sqft_per_unit): 0.037176194850681965
+                np.log1p(sum_income_gen_tt_CAR_45): 0.07464826547242646
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.11458127629906373
+                np.log1p(unit_residential_rent): 0.08764252133555292
+                residential_units_1500: 0.02350974365866962
+                sfdu: 0.013494570452768783
             T-Score:
-                jobs_1500: 11.530234915361216
-                np.log1p(sqft_per_unit): -2.5221360496005683
-                np.log1p(sum_income_45_gen_tt_min): -0.909854803595056
-                np.log1p(total_jobs_45_gen_tt_min): -2.236504822044402
-                np.log1p(unit_residential_rent): 3.8093884079978197
-                residential_units_1500: 7.823171474031879
-                sfdu: -6.072950123097971
+                jobs_1500: 11.689462938742198
+                np.log1p(sqft_per_unit): -6.193939220655926
+                np.log1p(sum_income_gen_tt_CAR_45): -4.254863007183491
+                np.log1p(total_jobs_gen_tt_CAR_45): 1.064825108372054
+                np.log1p(unit_residential_rent): -1.0714662971468245
+                residential_units_1500: 9.374298856195482
+                sfdu: -7.592241341976972
         fitted: true
         log_likelihoods:
-            convergence: -20610.036067279958
-            'null': -21500.47843783435
-            ratio: 0.041415002606987716
+            convergence: -20508.28808985
+            'null': -21371.381678655205
+            ratio: 0.04038548381114848
         name: 1
     2:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.11910480813668844
-                np.log1p(sqft_per_unit): -0.020104983919899552
-                np.log1p(sum_income_45_gen_tt_min): -0.024319235755422657
-                np.log1p(total_jobs_45_gen_tt_min): -0.11022266499174933
-                np.log1p(unit_residential_rent): 0.40885562324695635
-                residential_units_1500: 0.10178871726261056
-                sfdu: -0.016897589018578973
+                jobs_1500: 0.12150717520103647
+                np.log1p(sqft_per_unit): -0.1976361657979341
+                np.log1p(sum_income_gen_tt_CAR_45): -0.5498106350081263
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.36261194063098456
+                np.log1p(unit_residential_rent): 0.027020674812161378
+                residential_units_1500: 0.12607794549067283
+                sfdu: -0.045020607642280525
             Std. Error:
-                jobs_1500: 0.014129505485518714
-                np.log1p(sqft_per_unit): 0.04177781780597002
-                np.log1p(sum_income_45_gen_tt_min): 0.035862828152696084
-                np.log1p(total_jobs_45_gen_tt_min): 0.04506097855207299
-                np.log1p(unit_residential_rent): 0.09958122687745519
-                residential_units_1500: 0.025488173119384134
-                sfdu: 0.014756815504070084
+                jobs_1500: 0.01436098635088245
+                np.log1p(sqft_per_unit): 0.0373270840661957
+                np.log1p(sum_income_gen_tt_CAR_45): 0.07218791158066536
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.11016959819974755
+                np.log1p(unit_residential_rent): 0.0854081919078592
+                residential_units_1500: 0.02361063376345374
+                sfdu: 0.013966548864163184
             T-Score:
-                jobs_1500: 8.429510024873736
-                np.log1p(sqft_per_unit): -0.48123585614915876
-                np.log1p(sum_income_45_gen_tt_min): -0.6781181799683134
-                np.log1p(total_jobs_45_gen_tt_min): -2.446077926700476
-                np.log1p(unit_residential_rent): 4.105750009990284
-                residential_units_1500: 3.9935666156158804
-                sfdu: -1.145070155137363
+                jobs_1500: 8.460921292747425
+                np.log1p(sqft_per_unit): -5.294712157195214
+                np.log1p(sum_income_gen_tt_CAR_45): -7.616380955885505
+                np.log1p(total_jobs_gen_tt_CAR_45): 3.291397504904538
+                np.log1p(unit_residential_rent): 0.3163709968396481
+                residential_units_1500: 5.3398797657784804
+                sfdu: -3.2234597165087115
         fitted: true
         log_likelihoods:
-            convergence: -20987.03196307059
-            'null': -21312.701333573776
-            ratio: 0.015280529924667996
+            convergence: -20940.92147826285
+            'null': -21304.87728756292
+            ratio: 0.01708321547162972
         name: 2
     3:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.10184565723731055
-                np.log1p(sqft_per_unit): 0.05181593826889581
-                np.log1p(sum_income_45_gen_tt_min): -0.10148403081129924
-                np.log1p(total_jobs_45_gen_tt_min): 0.01837684618034629
-                np.log1p(unit_residential_rent): 0.7286156343347855
-                residential_units_1500: 0.07691760665245154
-                sfdu: 0.02804684242602139
+                jobs_1500: 0.11621296407985264
+                np.log1p(sqft_per_unit): -0.2138600676403877
+                np.log1p(sum_income_gen_tt_CAR_45): -1.0805177954079006
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.8948416111106976
+                np.log1p(unit_residential_rent): -0.09262271250545878
+                residential_units_1500: 0.12132276587341223
+                sfdu: -0.016990924207158302
             Std. Error:
-                jobs_1500: 0.014316146009851278
-                np.log1p(sqft_per_unit): 0.04446534681219086
-                np.log1p(sum_income_45_gen_tt_min): 0.03871484009788919
-                np.log1p(total_jobs_45_gen_tt_min): 0.04856948459740186
-                np.log1p(unit_residential_rent): 0.10438235840234587
-                residential_units_1500: 0.026187959929647064
-                sfdu: 0.01505597347307018
+                jobs_1500: 0.01409618459464599
+                np.log1p(sqft_per_unit): 0.03740619271552529
+                np.log1p(sum_income_gen_tt_CAR_45): 0.07247360063612461
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.11067018680836253
+                np.log1p(unit_residential_rent): 0.08458469540012135
+                residential_units_1500: 0.023424038288704815
+                sfdu: 0.014880628197527234
             T-Score:
-                jobs_1500: 7.11404152816185
-                np.log1p(sqft_per_unit): 1.165310561677429
-                np.log1p(sum_income_45_gen_tt_min): -2.621321192460055
-                np.log1p(total_jobs_45_gen_tt_min): 0.3783619763041366
-                np.log1p(unit_residential_rent): 6.980256486697763
-                residential_units_1500: 2.9371362587650087
-                sfdu: 1.862838193504212
+                jobs_1500: 8.244285061646584
+                np.log1p(sqft_per_unit): -5.717236963055744
+                np.log1p(sum_income_gen_tt_CAR_45): -14.909122575997891
+                np.log1p(total_jobs_gen_tt_CAR_45): 8.085660979864551
+                np.log1p(unit_residential_rent): -1.0950292138230706
+                residential_units_1500: 5.1794128910690285
+                sfdu: -1.1418149813044682
         fitted: true
         log_likelihoods:
-            convergence: -21075.902968149887
-            'null': -21410.50190870949
-            ratio: 0.01562779527478031
+            convergence: -21054.262811162396
+            'null': -21371.381678655205
+            ratio: 0.014838482240459583
         name: 3
     4:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.11539092682550138
-                np.log1p(sqft_per_unit): -0.05490349912864988
-                np.log1p(sum_income_45_gen_tt_min): -0.13596762799324014
-                np.log1p(total_jobs_45_gen_tt_min): 0.1064964909388199
-                np.log1p(unit_residential_rent): 0.33594986036026797
-                residential_units_1500: 0.0637554584410646
-                sfdu: 0.0001897476829553266
+                jobs_1500: 0.11428776213174618
+                np.log1p(sqft_per_unit): -0.14114035143026804
+                np.log1p(sum_income_gen_tt_CAR_45): -0.6436989639138692
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.6270513248419451
+                np.log1p(unit_residential_rent): 0.0017347616827154478
+                residential_units_1500: 0.07250651474253887
+                sfdu: -0.005098741170968248
             Std. Error:
-                jobs_1500: 0.014073307507008765
-                np.log1p(sqft_per_unit): 0.0449172633700891
-                np.log1p(sum_income_45_gen_tt_min): 0.039113717884620716
-                np.log1p(total_jobs_45_gen_tt_min): 0.04859105527132155
-                np.log1p(unit_residential_rent): 0.10669779087705551
-                residential_units_1500: 0.025596921849762
-                sfdu: 0.015246486879608423
+                jobs_1500: 0.014190000227217092
+                np.log1p(sqft_per_unit): 0.03869251719036664
+                np.log1p(sum_income_gen_tt_CAR_45): 0.07495527645074083
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.11423038305523579
+                np.log1p(unit_residential_rent): 0.08659437010941529
+                residential_units_1500: 0.024103665560088677
+                sfdu: 0.01502603732535114
             T-Score:
-                jobs_1500: 8.199275598009535
-                np.log1p(sqft_per_unit): -1.222325115318818
-                np.log1p(sum_income_45_gen_tt_min): -3.4762133427030166
-                np.log1p(total_jobs_45_gen_tt_min): 2.1916891976139925
-                np.log1p(unit_residential_rent): 3.1486112092739797
-                residential_units_1500: 2.490747083390318
-                sfdu: 0.012445338027943124
+                jobs_1500: 8.054105729507802
+                np.log1p(sqft_per_unit): -3.6477428112484773
+                np.log1p(sum_income_gen_tt_CAR_45): -8.587773861882768
+                np.log1p(total_jobs_gen_tt_CAR_45): 5.489356754925143
+                np.log1p(unit_residential_rent): 0.020033192464169555
+                residential_units_1500: 3.0081115489171317
+                sfdu: -0.3393270667819998
         fitted: true
         log_likelihoods:
-            convergence: -21102.76904314997
-            'null': -21398.765839693206
-            ratio: 0.013832423736988786
+            convergence: -21027.382982515628
+            'null': -21273.58110351949
+            ratio: 0.011572951437082257
         name: 4
     5:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.0922296316610875
-                np.log1p(sqft_per_unit): 0.04862558678911874
-                np.log1p(sum_income_45_gen_tt_min): -0.12583332026592003
-                np.log1p(total_jobs_45_gen_tt_min): 0.18505672012630625
-                np.log1p(unit_residential_rent): 0.31057446189698673
-                residential_units_1500: 0.12610060326249234
-                sfdu: -0.03723752580631335
+                jobs_1500: 0.11202916548975925
+                np.log1p(sqft_per_unit): -0.022607196762432297
+                np.log1p(sum_income_gen_tt_CAR_45): 0.14205234173535367
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.021736078435994528
+                np.log1p(unit_residential_rent): 0.14791996769818755
+                residential_units_1500: 0.08437884282243821
+                sfdu: -0.059982894410566374
             Std. Error:
-                jobs_1500: 0.014188706075687932
-                np.log1p(sqft_per_unit): 0.04143004870761151
-                np.log1p(sum_income_45_gen_tt_min): 0.03659015570431958
-                np.log1p(total_jobs_45_gen_tt_min): 0.04727327920171232
-                np.log1p(unit_residential_rent): 0.10019375401636416
-                residential_units_1500: 0.02548068375299531
-                sfdu: 0.01466133856015801
+                jobs_1500: 0.014202371123922197
+                np.log1p(sqft_per_unit): 0.03948150773283367
+                np.log1p(sum_income_gen_tt_CAR_45): 0.07860313491939154
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.12060970400091833
+                np.log1p(unit_residential_rent): 0.0895299505159047
+                residential_units_1500: 0.023109639945517468
+                sfdu: 0.014636195091806824
             T-Score:
-                jobs_1500: 6.5002144077902315
-                np.log1p(sqft_per_unit): 1.1736792088343664
-                np.log1p(sum_income_45_gen_tt_min): -3.4389938453053652
-                np.log1p(total_jobs_45_gen_tt_min): 3.914615682501737
-                np.log1p(unit_residential_rent): 3.099738750643699
-                residential_units_1500: 4.948870465364531
-                sfdu: -2.5398448888906926
+                jobs_1500: 7.888060698615283
+                np.log1p(sqft_per_unit): -0.5726021639146184
+                np.log1p(sum_income_gen_tt_CAR_45): 1.8072096218685176
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.18021832170178467
+                np.log1p(unit_residential_rent): 1.652184177985333
+                residential_units_1500: 3.6512400462043986
+                sfdu: -4.098257370465369
         fitted: true
         log_likelihoods:
-            convergence: -20793.752417989137
-            'null': -21152.3083903512
-            ratio: 0.016951150945096027
+            convergence: -20986.49710100244
+            'null': -21297.05324155206
+            ratio: 0.014582117865193922
         name: 5
     6:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.10910553071416897
-                np.log1p(sqft_per_unit): 0.1463967162995661
-                np.log1p(sum_income_45_gen_tt_min): 0.004262471928737753
-                np.log1p(total_jobs_45_gen_tt_min): 0.33052221403373605
-                np.log1p(unit_residential_rent): 0.29657547386040983
-                residential_units_1500: 0.08181752367294938
-                sfdu: -0.0797496945273612
+                jobs_1500: 0.07299452421036759
+                np.log1p(sqft_per_unit): 0.11962530852355893
+                np.log1p(sum_income_gen_tt_CAR_45): 0.8930133959603362
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.5528141381858174
+                np.log1p(unit_residential_rent): 0.24562700255814748
+                residential_units_1500: 0.2040631044559387
+                sfdu: -0.10954856369962174
             Std. Error:
-                jobs_1500: 0.014283420092669457
-                np.log1p(sqft_per_unit): 0.04541875633499744
-                np.log1p(sum_income_45_gen_tt_min): 0.04056752553886541
-                np.log1p(total_jobs_45_gen_tt_min): 0.05260271827282914
-                np.log1p(unit_residential_rent): 0.10833906542529426
-                residential_units_1500: 0.024954511436679268
-                sfdu: 0.01434457749593005
+                jobs_1500: 0.014359908635517091
+                np.log1p(sqft_per_unit): 0.03950876249494006
+                np.log1p(sum_income_gen_tt_CAR_45): 0.07909440151445024
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.12205411319249294
+                np.log1p(unit_residential_rent): 0.08924295432076157
+                residential_units_1500: 0.023148572334275676
+                sfdu: 0.013811784669447514
             T-Score:
-                jobs_1500: 7.6386138618274035
-                np.log1p(sqft_per_unit): 3.2232656310485557
-                np.log1p(sum_income_45_gen_tt_min): 0.10507103581297124
-                np.log1p(total_jobs_45_gen_tt_min): 6.283367568942926
-                np.log1p(unit_residential_rent): 2.7374749144842396
-                residential_units_1500: 3.2786666202845507
-                sfdu: -5.559570823887172
+                jobs_1500: 5.0832164788170395
+                np.log1p(sqft_per_unit): 3.0278171466109454
+                np.log1p(sum_income_gen_tt_CAR_45): 11.29047541749445
+                np.log1p(total_jobs_gen_tt_CAR_45): -4.529254473497078
+                np.log1p(unit_residential_rent): 2.7523405564914674
+                residential_units_1500: 8.81536457234497
+                sfdu: -7.931528496961704
         fitted: true
         log_likelihoods:
-            convergence: -20502.751178670536
-            'null': -21124.9242293132
-            ratio: 0.029452084366737297
+            convergence: -20691.967627699996
+            'null': -21230.548850459774
+            ratio: 0.02536821947248502
         name: 6
     7:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.10014017803091828
-                np.log1p(sqft_per_unit): 0.08384834033383375
-                np.log1p(sum_income_45_gen_tt_min): -0.06584694186365891
-                np.log1p(total_jobs_45_gen_tt_min): 0.5767414848986584
-                np.log1p(unit_residential_rent): -0.03730139979562885
-                residential_units_1500: 0.13371902842071703
-                sfdu: -0.13601159300992044
+                jobs_1500: 0.08382742024165815
+                np.log1p(sqft_per_unit): 0.09252753166718755
+                np.log1p(sum_income_gen_tt_CAR_45): 1.2089720474517924
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.6952758698798233
+                np.log1p(unit_residential_rent): -0.020919818073938896
+                residential_units_1500: 0.2305266015866235
+                sfdu: -0.15884622126205286
             Std. Error:
-                jobs_1500: 0.01482873803118256
-                np.log1p(sqft_per_unit): 0.04449347756822593
-                np.log1p(sum_income_45_gen_tt_min): 0.04015941792513606
-                np.log1p(total_jobs_45_gen_tt_min): 0.05330321355628814
-                np.log1p(unit_residential_rent): 0.10612570371448139
-                residential_units_1500: 0.024918937542972735
-                sfdu: 0.013973577874881968
+                jobs_1500: 0.014682557833575735
+                np.log1p(sqft_per_unit): 0.04061096382078399
+                np.log1p(sum_income_gen_tt_CAR_45): 0.0894278957540258
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.14044238679149346
+                np.log1p(unit_residential_rent): 0.09453002993492013
+                residential_units_1500: 0.023081099309938253
+                sfdu: 0.013421959080353396
             T-Score:
-                jobs_1500: 6.753115323794841
-                np.log1p(sqft_per_unit): 1.8845085823031342
-                np.log1p(sum_income_45_gen_tt_min): -1.6396388510014945
-                np.log1p(total_jobs_45_gen_tt_min): 10.820013399185022
-                np.log1p(unit_residential_rent): -0.3514831797580711
-                residential_units_1500: 5.3661609043370495
-                sfdu: -9.73348373822043
+                jobs_1500: 5.709319942194509
+                np.log1p(sqft_per_unit): 2.278387976101999
+                np.log1p(sum_income_gen_tt_CAR_45): 13.518958902679625
+                np.log1p(total_jobs_gen_tt_CAR_45): -4.95061274422841
+                np.log1p(unit_residential_rent): -0.22130341107837684
+                residential_units_1500: 9.987678597585836
+                sfdu: -11.834801485467684
         fitted: true
         log_likelihoods:
-            convergence: -20224.41705857816
-            'null': -21175.780528383773
-            ratio: 0.04492696118239492
+            convergence: -20466.282623028936
+            'null': -21351.821563628062
+            ratio: 0.041473695251725284
         name: 7
     8:
         fit_parameters:
             Coefficient:
-                jobs_1500: 0.14671204045333494
-                np.log1p(sqft_per_unit): 0.14145678320563568
-                np.log1p(sum_income_45_gen_tt_min): 0.8776732082935524
-                np.log1p(total_jobs_45_gen_tt_min): -0.21164945780891195
-                np.log1p(unit_residential_rent): -0.16564766888854865
-                residential_units_1500: 0.1856969589189957
-                sfdu: -0.16523979723144738
+                jobs_1500: 0.14064558737207536
+                np.log1p(sqft_per_unit): 0.21747038871277763
+                np.log1p(sum_income_gen_tt_CAR_45): 2.948707280636931
+                np.log1p(total_jobs_gen_tt_CAR_45): -2.4762847288988055
+                np.log1p(unit_residential_rent): 0.038401723017553596
+                residential_units_1500: 0.27530550434443257
+                sfdu: -0.16964692072630455
             Std. Error:
-                jobs_1500: 0.015059877943030956
-                np.log1p(sqft_per_unit): 0.04442025717239569
-                np.log1p(sum_income_45_gen_tt_min): 0.041215439240331546
-                np.log1p(total_jobs_45_gen_tt_min): 0.05577077459786238
-                np.log1p(unit_residential_rent): 0.10582792443133208
-                residential_units_1500: 0.024433893489484017
-                sfdu: 0.013449401231905937
+                jobs_1500: 0.015130522869780677
+                np.log1p(sqft_per_unit): 0.04054825182877945
+                np.log1p(sum_income_gen_tt_CAR_45): 0.0842721806796019
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.13185164286571863
+                np.log1p(unit_residential_rent): 0.09415619372065097
+                residential_units_1500: 0.02309700130154462
+                sfdu: 0.01351217007456921
             T-Score:
-                jobs_1500: 9.741914310881036
-                np.log1p(sqft_per_unit): 3.1845106762133266
-                np.log1p(sum_income_45_gen_tt_min): 21.294767797469003
-                np.log1p(total_jobs_45_gen_tt_min): -3.7949886716657546
-                np.log1p(unit_residential_rent): -1.5652548207730506
-                residential_units_1500: 7.599974150616515
-                sfdu: -12.286033733565027
+                jobs_1500: 9.2954875771662
+                np.log1p(sqft_per_unit): 5.363249435045342
+                np.log1p(sum_income_gen_tt_CAR_45): 34.99028097834267
+                np.log1p(total_jobs_gen_tt_CAR_45): -18.780840913910513
+                np.log1p(unit_residential_rent): 0.40785126819682677
+                residential_units_1500: 11.91953452096058
+                sfdu: -12.555120294525539
         fitted: true
         log_likelihoods:
-            convergence: -19917.340583520403
+            convergence: -20084.62475156774
             'null': -21496.56641482892
-            ratio: 0.07346409658330944
+            ratio: 0.06568219482192217
         name: 8
 
 fitted: true

--- a/configs/nrh.yaml
+++ b/configs/nrh.yaml
@@ -13,7 +13,7 @@ min_segment_size: 10
 
 default_config:
     model_expression: np.log1p(costar_rent) ~ office_1500 + retail_1500 + industrial_1500
-        + np.log1p(total_jobs_45_gen_tt_min) + np.log1p(sum_income_45_gen_tt_min)
+        + np.log1p(total_jobs_gen_tt_CAR_45) + np.log1p(sum_income_gen_tt_CAR_45)
         + juris_ave_income + I(transit_type == "bart1") + I(transit_type == "bart2")
         + I(transit_type == "bart3a") + I(transit_type == "lrt1")
     ytransform: np.expm1
@@ -22,113 +22,113 @@ models:
     Industrial:
         fit_parameters:
             Coefficient:
-                I(transit_type == "bart1")[T.True]: 0.1975326111110003
-                I(transit_type == "bart2")[T.True]: -0.08920517418717384
-                I(transit_type == "bart3a")[T.True]: 7.228186541003156e-16
-                I(transit_type == "lrt1")[T.True]: -0.009527519621790978
-                Intercept: -8.5139842683687
-                industrial_1500: 0.0018058166431284342
-                juris_ave_income: 0.6352153300541367
-                np.log1p(sum_income_45_gen_tt_min): 0.20917691877473496
-                np.log1p(total_jobs_45_gen_tt_min): -0.12710393874943593
-                office_1500: 0.042186310307194254
-                retail_1500: 0.027332173121031696
+                I(transit_type == "bart1")[T.True]: 0.2120821210368145
+                I(transit_type == "bart2")[T.True]: -0.05384628304518587
+                I(transit_type == "bart3a")[T.True]: 6.717566263696623e-17
+                I(transit_type == "lrt1")[T.True]: 0.02192283888387915
+                Intercept: -10.328747397792979
+                industrial_1500: 0.008302084608862371
+                juris_ave_income: 0.6627088954585715
+                np.log1p(sum_income_gen_tt_CAR_45): 0.3797177710770086
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.3462381178726065
+                office_1500: 0.04992910577693081
+                retail_1500: 0.026831607582385713
             Std. Error:
-                I(transit_type == "bart1")[T.True]: 0.0650353804812545
-                I(transit_type == "bart2")[T.True]: 0.11161421991555874
-                I(transit_type == "bart3a")[T.True]: 1.7077794820057173e-16
-                I(transit_type == "lrt1")[T.True]: 0.0877975122132252
-                Intercept: 1.3016840151188043
-                industrial_1500: 0.010670926337073396
-                juris_ave_income: 0.05671181141100368
-                np.log1p(sum_income_45_gen_tt_min): 0.09495280321615283
-                np.log1p(total_jobs_45_gen_tt_min): 0.0890508683755523
-                office_1500: 0.007298739239979734
-                retail_1500: 0.007351502959490597
+                I(transit_type == "bart1")[T.True]: 0.06567222061131771
+                I(transit_type == "bart2")[T.True]: 0.11240769888033078
+                I(transit_type == "bart3a")[T.True]: 4.72066547243409e-16
+                I(transit_type == "lrt1")[T.True]: 0.08824927712891707
+                Intercept: 1.900495375389461
+                industrial_1500: 0.01097648018964271
+                juris_ave_income: 0.05834969333669395
+                np.log1p(sum_income_gen_tt_CAR_45): 0.14789359067540098
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.1421405444963126
+                office_1500: 0.0071979060900558955
+                retail_1500: 0.007443341256984201
             T-Score:
-                I(transit_type == "bart1")[T.True]: 3.0373099941798016
-                I(transit_type == "bart2")[T.True]: -0.7992276813354215
-                I(transit_type == "bart3a")[T.True]: 4.232505787289321
-                I(transit_type == "lrt1")[T.True]: -0.10851696570459111
-                Intercept: -6.540745810412085
-                industrial_1500: 0.16922773019757315
-                juris_ave_income: 11.200758964487724
-                np.log1p(sum_income_45_gen_tt_min): 2.2029567499819844
-                np.log1p(total_jobs_45_gen_tt_min): -1.427318352622944
-                office_1500: 5.77994485350478
-                retail_1500: 3.7179027569793166
-        fit_rsquared: 0.29401509182153673
-        fit_rsquared_adj: 0.2863690458845859
+                I(transit_type == "bart1")[T.True]: 3.2294038341116345
+                I(transit_type == "bart2")[T.True]: -0.47902664658681976
+                I(transit_type == "bart3a")[T.True]: 0.14230125610304858
+                I(transit_type == "lrt1")[T.True]: 0.24841947262472913
+                Intercept: -5.434765867649823
+                industrial_1500: 0.7563521698600733
+                juris_ave_income: 11.357538618661746
+                np.log1p(sum_income_gen_tt_CAR_45): 2.567506606222164
+                np.log1p(total_jobs_gen_tt_CAR_45): -2.4358856869412695
+                office_1500: 6.936615336772626
+                retail_1500: 3.604779984688893
+        fit_rsquared: 0.280715090835264
+        fit_rsquared_adj: 0.2729250015663319
         fitted: true
         name: Industrial
     Office:
         fit_parameters:
             Coefficient:
-                I(transit_type == "bart1")[T.True]: 0.022894921407310847
-                I(transit_type == "bart3a")[T.True]: -5.49364892070762e-14
-                I(transit_type == "lrt1")[T.True]: -0.06149793207813961
-                Intercept: -6.47643428637141
-                industrial_1500: -0.022475701586216583
-                juris_ave_income: 0.7215354077590966
-                np.log1p(sum_income_45_gen_tt_min): -0.049890020082657124
-                np.log1p(total_jobs_45_gen_tt_min): 0.16566902509294124
-                office_1500: 0.11165618046425108
-                retail_1500: -0.004588196575033468
+                I(transit_type == "bart1")[T.True]: 0.0347414403862744
+                I(transit_type == "bart3a")[T.True]: 3.0799502228844385e-13
+                I(transit_type == "lrt1")[T.True]: -0.02500827273883434
+                Intercept: -16.758762904556388
+                industrial_1500: -0.021504783934531577
+                juris_ave_income: 0.7239769869320815
+                np.log1p(sum_income_gen_tt_CAR_45): 0.7883457026837071
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.6432089752580821
+                office_1500: 0.11171082353740346
+                retail_1500: -0.00018084741466540752
             Std. Error:
-                I(transit_type == "bart1")[T.True]: 0.033121724635468724
-                I(transit_type == "bart3a")[T.True]: 6.4919362379566036e-15
-                I(transit_type == "lrt1")[T.True]: 0.03877635053974985
-                Intercept: 0.7632012837589405
-                industrial_1500: 0.003362494255154586
-                juris_ave_income: 0.03324015766929633
-                np.log1p(sum_income_45_gen_tt_min): 0.05644746803973244
-                np.log1p(total_jobs_45_gen_tt_min): 0.051690616668572685
-                office_1500: 0.00635198805689838
-                retail_1500: 0.0051764163815569185
+                I(transit_type == "bart1")[T.True]: 0.03247054228617986
+                I(transit_type == "bart3a")[T.True]: 2.41891338511657e-14
+                I(transit_type == "lrt1")[T.True]: 0.03782478080374758
+                Intercept: 1.3116955484366761
+                industrial_1500: 0.003373978585218072
+                juris_ave_income: 0.032967371756748534
+                np.log1p(sum_income_gen_tt_CAR_45): 0.1063095354558976
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.10412691288238707
+                office_1500: 0.0062488809390755145
+                retail_1500: 0.005171666638697652
             T-Score:
-                I(transit_type == "bart1")[T.True]: 0.6912357873657822
-                I(transit_type == "bart3a")[T.True]: -8.462265677515028
-                I(transit_type == "lrt1")[T.True]: -1.5859649302246157
-                Intercept: -8.485879707216284
-                industrial_1500: -6.684234940107963
-                juris_ave_income: 21.706738425779886
-                np.log1p(sum_income_45_gen_tt_min): -0.8838309638182595
-                np.log1p(total_jobs_45_gen_tt_min): 3.205011581795776
-                office_1500: 17.578147103565527
-                retail_1500: -0.8863654383331252
-        fit_rsquared: 0.40701454641534185
-        fit_rsquared_adj: 0.40503214623620387
+                I(transit_type == "bart1")[T.True]: 1.0699371781376463
+                I(transit_type == "bart3a")[T.True]: 12.732784240374992
+                I(transit_type == "lrt1")[T.True]: -0.6611610750261528
+                Intercept: -12.77641212134177
+                industrial_1500: -6.37371678313176
+                juris_ave_income: 21.96040959145859
+                np.log1p(sum_income_gen_tt_CAR_45): 7.415569067280437
+                np.log1p(total_jobs_gen_tt_CAR_45): -6.177163592515187
+                office_1500: 17.87693262626483
+                retail_1500: -0.034968884752198406
+        fit_rsquared: 0.4144935133092178
+        fit_rsquared_adj: 0.4125361159446018
         fitted: true
         model_expression: np.log1p(costar_rent) ~ office_1500 + retail_1500 + industrial_1500
-            + np.log1p(total_jobs_45_gen_tt_min) + np.log1p(sum_income_45_gen_tt_min)
+            + np.log1p(total_jobs_gen_tt_CAR_45) + np.log1p(sum_income_gen_tt_CAR_45)
             + juris_ave_income + I(transit_type == "bart1") + I(transit_type == "bart3a")
             + I(transit_type == "lrt1")
         name: Office
     Retail:
         fit_parameters:
             Coefficient:
-                Intercept: -2.5480406784283574
-                np.log1p(sum_income_45_gen_tt_min): 0.2625738935678558
-                np.log1p(total_jobs_45_gen_tt_min): -0.06921193945464806
-                office_1500: 0.028012413327283214
-                sum_income_3000: 4.812854727410788e-11
+                Intercept: -7.070996437280712
+                np.log1p(sum_income_gen_tt_CAR_45): 0.6619342344974977
+                np.log1p(total_jobs_gen_tt_CAR_45): -0.4945736568804715
+                office_1500: 0.0292235659260804
+                sum_income_3000: 5.791876572438562e-11
             Std. Error:
-                Intercept: 1.137033369035898
-                np.log1p(sum_income_45_gen_tt_min): 0.08774697140095403
-                np.log1p(total_jobs_45_gen_tt_min): 0.0815582577941596
-                office_1500: 0.010630610381563687
-                sum_income_3000: 6.2724346102436775e-12
+                Intercept: 2.1775057212710194
+                np.log1p(sum_income_gen_tt_CAR_45): 0.18196426361008727
+                np.log1p(total_jobs_gen_tt_CAR_45): 0.17905319904104156
+                office_1500: 0.010810263549434661
+                sum_income_3000: 6.121663417529857e-12
             T-Score:
-                Intercept: -2.240955057096404
-                np.log1p(sum_income_45_gen_tt_min): 2.9923983628795763
-                np.log1p(total_jobs_45_gen_tt_min): -0.8486196410586438
-                office_1500: 2.6350710186749207
-                sum_income_3000: 7.673024951987205
-        fit_rsquared: 0.27275719626256145
-        fit_rsquared_adj: 0.27000509482930724
+                Intercept: -3.2472917835335657
+                np.log1p(sum_income_gen_tt_CAR_45): 3.6377155676891
+                np.log1p(total_jobs_gen_tt_CAR_45): -2.7621604055625286
+                office_1500: 2.7033166945877736
+                sum_income_3000: 9.46127903055414
+        fit_rsquared: 0.25468698248067856
+        fit_rsquared_adj: 0.25186649802459793
         fitted: true
         model_expression: np.log1p(costar_rent) ~ office_1500 + sum_income_3000 +
-            np.log1p(total_jobs_45_gen_tt_min) + np.log1p(sum_income_45_gen_tt_min)
+            np.log1p(total_jobs_gen_tt_CAR_45) + np.log1p(sum_income_gen_tt_CAR_45)
         name: Retail
 
 fitted: true

--- a/configs/rrh.yaml
+++ b/configs/rrh.yaml
@@ -10,8 +10,8 @@ fit_filters:
 
 predict_filters: null
 
-model_expression: price_per_sqft ~ sqft_per_unit + residential_units_1500 + np.log1p(total_jobs_45_gen_tt_min)
-    + np.log1p(sum_income_45_gen_tt_min) + sfdu + ave_income_1500
+model_expression: price_per_sqft ~ sqft_per_unit + residential_units_1500 + np.log1p(total_jobs_gen_tt_CAR_45)
+    + np.log1p(sum_income_gen_tt_CAR_45) + sfdu + ave_income_1500
 
 ytransform: null
 
@@ -19,30 +19,30 @@ fitted: true
 
 fit_parameters:
     Coefficient:
-        Intercept: 5.480966236643463
-        ave_income_1500: 0.05856651727763514
-        np.log1p(sum_income_45_gen_tt_min): -0.09890138330012574
-        np.log1p(total_jobs_45_gen_tt_min): -0.07833105756502375
-        residential_units_1500: 0.3616434791678832
-        sfdu: -0.21610352459641285
-        sqft_per_unit: -0.0009117231504373579
+        Intercept: 83.81154304052637
+        ave_income_1500: 0.05734541684428735
+        np.log1p(sum_income_gen_tt_CAR_45): -3.895810853035732
+        np.log1p(total_jobs_gen_tt_CAR_45): 1.3077008646616746
+        residential_units_1500: 0.3571073041807892
+        sfdu: -0.21238981594086453
+        sqft_per_unit: -0.0009093530396603749
     Std. Error:
-        Intercept: 0.10998139094855704
-        ave_income_1500: 0.0013118304661540892
-        np.log1p(sum_income_45_gen_tt_min): 0.007844857651794298
-        np.log1p(total_jobs_45_gen_tt_min): 0.007919298216252584
-        residential_units_1500: 0.0010718146055757483
-        sfdu: 0.0008949284401021891
-        sqft_per_unit: 2.3986237771584608e-06
+        Intercept: 0.9461248569110442
+        ave_income_1500: 0.0013062194895536784
+        np.log1p(sum_income_gen_tt_CAR_45): 0.043850786474148654
+        np.log1p(total_jobs_gen_tt_CAR_45): 0.016457819749440356
+        residential_units_1500: 0.0010708670627471157
+        sfdu: 0.0008666624947497485
+        sqft_per_unit: 2.3527945099559678e-06
     T-Score:
-        Intercept: 49.83539660093172
-        ave_income_1500: 44.64488269534964
-        np.log1p(sum_income_45_gen_tt_min): -12.607160982392681
-        np.log1p(total_jobs_45_gen_tt_min): -9.891161492601304
-        residential_units_1500: 337.4123447157343
-        sfdu: -241.47575930399157
-        sqft_per_unit: -380.1026068029036
+        Intercept: 88.5840197816581
+        ave_income_1500: 43.90182301129321
+        np.log1p(sum_income_gen_tt_CAR_45): -88.84243969791576
+        np.log1p(total_jobs_gen_tt_CAR_45): 79.45772189576584
+        residential_units_1500: 333.4749163586141
+        sfdu: -245.0663519276818
+        sqft_per_unit: -386.4991336100123
 
-fit_rsquared_adj: 0.3917351591196758
+fit_rsquared_adj: 0.39795570341854225
 
-fit_rsquared: 0.3917420849537545
+fit_rsquared: 0.39796255842416794

--- a/configs/rsh.yaml
+++ b/configs/rsh.yaml
@@ -18,7 +18,7 @@ predict_filters:
 - combo_logsum > 0
 
 model_expression: price_per_sqft ~ sqft_per_unit + residential_units_1500 + sfdu +
-    np.log1p(total_jobs_45_gen_tt_min) + np.log1p(sum_income_45_gen_tt_min) + ave_income_1500
+    np.log1p(total_jobs_gen_tt_CAR_45) + np.log1p(sum_income_gen_tt_CAR_45) + ave_income_1500
     + is_sanfran + pacheights + stanford + modern_condo + historic + new_construction
     + I(transit_type == "bart1") + I(transit_type == "bart2")
 
@@ -28,54 +28,54 @@ fitted: true
 
 fit_parameters:
     Coefficient:
-        I(transit_type == "bart1")[T.True]: -4.623146987146627
-        I(transit_type == "bart2")[T.True]: 19.509529438862057
-        Intercept: -4250.719077734194
-        ave_income_1500: 382.5716437915825
-        historic: 60.775203069290335
-        is_sanfran: 105.93049071445162
-        modern_condo: 9.523609917887484
-        new_construction: -8.970734316395507
-        np.log1p(sum_income_45_gen_tt_min): 1.9158742820338288
-        np.log1p(total_jobs_45_gen_tt_min): 22.844470594610005
-        pacheights: -1.2638372784635445
-        residential_units_1500: 72.69815741510723
-        sfdu: -70.76800249467723
-        sqft_per_unit: -0.09176560958754586
-        stanford: -1.3718830890984537
+        I(transit_type == "bart1")[T.True]: -3.1402739475927834
+        I(transit_type == "bart2")[T.True]: 23.158697139585186
+        Intercept: -5048.2061389270675
+        ave_income_1500: 387.7936196335122
+        historic: 61.564146301479454
+        is_sanfran: 113.86998010088968
+        modern_condo: 12.59869663490644
+        new_construction: -16.061391450269873
+        np.log1p(sum_income_gen_tt_CAR_45): 67.2829310103449
+        np.log1p(total_jobs_gen_tt_CAR_45): -48.548220898049195
+        pacheights: -1.156232615154225
+        residential_units_1500: 80.26994695301725
+        sfdu: -73.20048169088298
+        sqft_per_unit: -0.09220416254311734
+        stanford: -1.5484681185810976
     Std. Error:
-        I(transit_type == "bart1")[T.True]: 3.4945378357611436
-        I(transit_type == "bart2")[T.True]: 3.7431269267495906
-        Intercept: 34.72694066247876
-        ave_income_1500: 1.6607322970864598
-        historic: 1.356518336590475
-        is_sanfran: 2.1119689176241945
-        modern_condo: 4.886816890241954
-        new_construction: 1.5877376959503773
-        np.log1p(sum_income_45_gen_tt_min): 2.2841491059133125
-        np.log1p(total_jobs_45_gen_tt_min): 2.111141474821552
-        pacheights: 0.027650264041500245
-        residential_units_1500: 1.0146551761065488
-        sfdu: 0.9812558674422805
-        sqft_per_unit: 0.00075553489043598
-        stanford: 0.02220947274350229
+        I(transit_type == "bart1")[T.True]: 3.5078360669793645
+        I(transit_type == "bart2")[T.True]: 3.753863034158958
+        Intercept: 63.195853680968796
+        ave_income_1500: 1.6757865234712757
+        historic: 1.3625705629325295
+        is_sanfran: 2.106986068450955
+        modern_condo: 4.90442303211283
+        new_construction: 1.5865662662745683
+        np.log1p(sum_income_gen_tt_CAR_45): 4.904793922417712
+        np.log1p(total_jobs_gen_tt_CAR_45): 4.693589080318673
+        pacheights: 0.028600528935202065
+        residential_units_1500: 0.9994257053138216
+        sfdu: 0.9843353313064623
+        sqft_per_unit: 0.0007581652751935762
+        stanford: 0.021386243305625857
     T-Score:
-        I(transit_type == "bart1")[T.True]: -1.3229637807426005
-        I(transit_type == "bart2")[T.True]: 5.212094011410801
-        Intercept: -122.40407581676051
-        ave_income_1500: 230.3632225752188
-        historic: 44.802345408794885
-        is_sanfran: 50.157220511377325
-        modern_condo: 1.9488370716128784
-        new_construction: -5.650010287767254
-        np.log1p(sum_income_45_gen_tt_min): 0.8387693592655241
-        np.log1p(total_jobs_45_gen_tt_min): 10.820909383413529
-        pacheights: -45.707964183150395
-        residential_units_1500: 71.64814128684168
-        sfdu: -72.11982607466034
-        sqft_per_unit: -121.45780525713734
-        stanford: -61.77017820019246
+        I(transit_type == "bart1")[T.True]: -0.8952168481171092
+        I(transit_type == "bart2")[T.True]: 6.169297315551585
+        Intercept: -79.8819201717235
+        ave_income_1500: 231.40991659858
+        historic: 45.18235457030634
+        is_sanfran: 54.04401187360782
+        modern_condo: 2.5688437870089094
+        new_construction: -10.123366285849366
+        np.log1p(sum_income_gen_tt_CAR_45): 13.717789590062784
+        np.log1p(total_jobs_gen_tt_CAR_45): -10.343517523002461
+        pacheights: -40.42696615065438
+        residential_units_1500: 80.31607204640822
+        sfdu: -74.36539090162232
+        sqft_per_unit: -121.61485834282715
+        stanford: -72.40486776720427
 
-fit_rsquared_adj: 0.5166983010602715
+fit_rsquared_adj: 0.5131247853545704
 
-fit_rsquared: 0.5167500092524946
+fit_rsquared: 0.5131768758753419

--- a/configs/settings.yaml
+++ b/configs/settings.yaml
@@ -1083,8 +1083,7 @@ non_residential_developer:
 
 
 # location of the hdf store
-# store: 2015_09_01_bayarea_v3.h5
-store: baus_model_data_2025.h5
+store: baus_model_data.h5
 
 
 # active scenario if not specified on the command line

--- a/scripts/make_csvs_from_output_store.py
+++ b/scripts/make_csvs_from_output_store.py
@@ -1,18 +1,49 @@
 import pandas as pd
+import argparse
+import os
 
-py2_store = pd.HDFStore('./output/model_data_output_2040.h5')
+year = 2010
 
-years = ['2040']
-scenario = 'b-ht'
+if __name__ == "__main__":
 
-print('scenario: {0}'.format(scenario))
-for table in py2_store.keys():
-    for year in years:
+    parser = argparse.ArgumentParser(description='Make csvs from H5 store.')
+
+    parser.add_argument('--year', '-y', action='store',
+                        help='specify the simulation year')
+    parser.add_argument(
+        '--datastore-filepath', '-d', action='store',
+        dest='datastore_filepath',
+        help='full pandas-compatible path to the input data file',
+        required=True)
+    parser.add_argument(
+        '--output-data-dir', '-o', action='store', dest='output_data_dir',
+        help='full path to the LOCAL output data directory',
+        required=True)
+
+    options = parser.parse_args()
+
+    if options.year:
+        year = options.year
+    datastore_filepath = options.datastore_filepath
+    output_data_dir = options.output_data_dir
+
+    py2_store = pd.HDFStore(datastore_filepath)
+
+    for table in py2_store.keys():
         if year in table:
-            print(year)
+            print('year: {0}'.format(year))
+
             table_name = table.split('/')[2]
-            print(table_name)
+            print('table: {0}'.format(table_name))
             df = py2_store[table]
-            df.to_csv(
-                '/home/data/spring_2019/{0}/{1}/{2}.csv'.format(
-                    year, scenario, table_name))
+
+            if not os.path.exists(output_data_dir):
+                os.makedirs(output_data_dir)
+
+            fname = '{0}.csv'.format(table_name)
+            output_filepath = os.path.join(output_data_dir, fname)
+
+            if os.path.exists(output_filepath):
+                os.remove(output_filepath)
+
+            df.to_csv(output_filepath)

--- a/scripts/make_model_data_hdf.py
+++ b/scripts/make_model_data_hdf.py
@@ -1,8 +1,19 @@
 import pandas as pd
 import numpy as np
+import argparse
+import os
 
+"""
+This script takes the individual UrbanSim input .csv files and
+compiles them into an (python 2) .h5 data store object, stored
+locally, and used for either estimation, simulation or both in
+bayarea_urbansim UrbanSim implementation. The last simulation
+step in bayarea_urbansim then converts the updated .h5 back to
+individual csv's for use in ActivitySynth and elsewhere.
+"""
 
-local_data_dir = '/home/data/spring_2019/2025/'
+baseyear = False
+beam_bucket = 'urbansim-beam'
 csv_fnames = {
     'parcels': 'parcels.csv',
     'buildings': 'buildings.csv',
@@ -12,147 +23,213 @@ csv_fnames = {
     'persons': 'persons.csv',
     'rentals': 'craigslist.csv',
     'units': 'units.csv',
-    'skims': 'skims.csv',
-    'beam_skims': 'smart-1Apr2019-sc-b-ht-2025-20.skimsExcerpt.csv',
-    'zones': 'zones.csv'
+    'mtc_skims': 'mtc_skims.csv',
+    'beam_skims_raw': '30.skims-smart-23April2019-baseline.csv.gz',
+    'zones': 'zones.csv',
+    # the following nodes and edges .csv's aren't used by bayarea_urbansim
+    # they're just being loaded here so they can be passed through to the
+    # output data directory for use in activitysynth
+    'drive_nodes': 'bay_area_tertiary_strongly_nodes.{0}',
+    'drive_edges': 'bay_area_tertiary_strongly_edges.{0}',
+    'walk_nodes': 'bayarea_walk_nodes.{0}',
+    'walk_edges': 'bayarea_walk_edges.{0}',
 }
+data_store_fname = 'baus_model_data.h5'
+nodes_and_edges = False
 
-try:
-    parcels = pd.read_csv(
-        local_data_dir + csv_fnames['parcels'], index_col='parcel_id',
-        dtype={'parcel_id': int, 'block_id': str, 'apn': str})
-except ValueError:
-    parcels = pd.read_csv(
-        local_data_dir + csv_fnames['parcels'], index_col='primary_id',
-        dtype={'primary_id': int, 'block_id': str, 'apn': str})
 
-buildings = pd.read_csv(
-    local_data_dir + csv_fnames['buildings'], index_col='building_id',
-    dtype={'building_id': int, 'parcel_id': int})
-buildings['res_sqft_per_unit'] = buildings[
-    'residential_sqft'] / buildings['residential_units']
-buildings['res_sqft_per_unit'][buildings['res_sqft_per_unit'] == np.inf] = 0
+if __name__ == "__main__":
 
-# building_types = pd.read_csv(
-#     d + 'building_types.csv',
-#     index_col='building_type_id', dtype={'building_type_id': int})
+    parser = argparse.ArgumentParser(description='Make H5 store from csvs.')
 
-# building_types.head()
+    parser.add_argument(
+        '--baseyear', '-b', action='store_true',
+        help='specify the simulation year')
+    parser.add_argument(
+        '--input-data-dir', '-i', action='store', dest='input_data_dir',
+        help='full (pandas-compatible) path to input data directory',
+        required=True)
+    parser.add_argument(
+        '--output-data-dir', '-o', action='store', dest='output_data_dir',
+        help='full path to the LOCAL output data directory',
+        required=True)
+    parser.add_argument(
+        '--output-fname', '-f', action='store', dest='output_fname',
+        help='filename of the .h5 datastore')
+    parser.add_argument(
+        '--nodes-and-edges', '-n', action='store_true', dest='nodes_and_edges')
 
-try:
-    rentals = pd.read_csv(
-        local_data_dir + csv_fnames['rentals'],
-        index_col='pid', dtype={
-            'pid': int, 'date': str, 'region': str,
-            'neighborhood': str, 'rent': float, 'sqft': float,
-            'rent_sqft': float, 'longitude': float,
-            'latitude': float, 'county': str, 'fips_block': str,
-            'state': str, 'bathrooms': str})
-except ValueError:
-    rentals = pd.read_csv(
-        local_data_dir + csv_fnames['rentals'],
-        index_col=0, dtype={
-            'date': str, 'region': str,
-            'neighborhood': str, 'rent': float, 'sqft': float,
-            'rent_sqft': float, 'longitude': float,
-            'latitude': float, 'county': str, 'fips_block': str,
-            'state': str, 'bathrooms': str})
+    options = parser.parse_args()
 
-units = pd.read_csv(
-    local_data_dir + csv_fnames['units'], index_col='unit_id',
-    dtype={'unit_id': int, 'building_id': int})
+    if options.baseyear:
+        baseyear = options.baseyear
 
-try:
-    households = pd.read_csv(
-        local_data_dir + csv_fnames['households'],
-        index_col='household_id', dtype={
-            'household_id': int, 'block_group_id': str, 'state': str,
-            'county': str, 'tract': str, 'block_group': str,
-            'building_id': int, 'unit_id': int, 'persons': float})
-except ValueError:
-    households = pd.read_csv(
-        local_data_dir + csv_fnames['households'],
-        index_col=0, dtype={
-            'household_id': int, 'block_group_id': str, 'state': str,
-            'county': str, 'tract': str, 'block_group': str,
-            'building_id': int, 'unit_id': int, 'persons': float})
-    households.index.name = 'household_id'
+    if options.nodes_and_edges:
+        nodes_and_edges = options.nodes_and_edges
 
-try:
-    persons = pd.read_csv(
-        local_data_dir + csv_fnames['persons'], index_col='person_id',
-        dtype={'person_id': int, 'household_id': int})
-except ValueError:
-    persons = pd.read_csv(
-        local_data_dir + csv_fnames['persons'], index_col=0,
-        dtype={'person_id': int, 'household_id': int})
-    persons.index.name = 'person_id'
+    if options.output_fname:
+        data_store_fname = options.output_fname
 
-try:
-    jobs = pd.read_csv(
-        local_data_dir + csv_fnames['jobs'], index_col='job_id',
-        dtype={'job_id': int, 'building_id': int})
-except ValueError:
-    jobs = pd.read_csv(
-        local_data_dir + csv_fnames['jobs'], index_col=0,
-        dtype={'job_id': int, 'building_id': int})
-    jobs.index.name = 'job_id'
+    input_data_dir = options.input_data_dir
+    output_data_dir = options.output_data_dir
 
-establishments = pd.read_csv(
-    local_data_dir + csv_fnames['establishments'],
-    index_col='establishment_id', dtype={
-        'establishment_id': int, 'building_id': int,
-        'primary_id': int})
+    try:
+        parcels = pd.read_csv(
+            input_data_dir + csv_fnames['parcels'], index_col='parcel_id',
+            dtype={'parcel_id': int, 'block_id': str, 'apn': str})
+    except ValueError:
+        parcels = pd.read_csv(
+            input_data_dir + csv_fnames['parcels'], index_col='primary_id',
+            dtype={'primary_id': int, 'block_id': str, 'apn': str})
 
-zones = pd.read_csv(
-    local_data_dir + 'zones.csv', index_col='zone_id')
+    buildings = pd.read_csv(
+        input_data_dir + csv_fnames['buildings'], index_col='building_id',
+        dtype={'building_id': int, 'parcel_id': int})
+    buildings['res_sqft_per_unit'] = buildings[
+        'residential_sqft'] / buildings['residential_units']
+    buildings['res_sqft_per_unit'][
+        buildings['res_sqft_per_unit'] == np.inf] = 0
 
-# beam_nodes_fname = 'beam-network-nodes.csv'
-# beam_links_fname = '10.linkstats.csv'
-# beam_links_filtered_fname = 'beam_links_8am.csv'
-# with open(b + beam_links_filtered_fname, 'w') as f:
-#     p1 = subprocess.Popen(
-#         ["cat", b + beam_links_fname], stdout=PIPE)
-#     p2 = subprocess.Popen([
-#         "awk", "-F", ",",
-#         '(NR==1) || ($4 == "8.0" && $8 == "AVG")'],
-#         stdin=p1.stdout, stdout=f)
-#     p2.wait()
+    # building_types = pd.read_csv(
+    #     d + 'building_types.csv',
+    #     index_col='building_type_id', dtype={'building_type_id': int})
 
-# nodesbeam = pd.read_csv(b + beam_nodes_fname).set_index('id')
-# edgesbeam = pd.read_csv(b + beam_links_filtered_fname).set_index('link')
+    # building_types.head()
 
-# nodeswalk = pd.read_csv(d + 'bayarea_walk_nodes.csv').set_index('osmid')
-# edgeswalk = pd.read_csv(d + 'bayarea_walk_edges.csv').set_index('uniqueid')
+    try:
+        rentals = pd.read_csv(
+            input_data_dir + csv_fnames['rentals'],
+            index_col='pid', dtype={
+                'pid': int, 'date': str, 'region': str,
+                'neighborhood': str, 'rent': float, 'sqft': float,
+                'rent_sqft': float, 'longitude': float,
+                'latitude': float, 'county': str, 'fips_block': str,
+                'state': str, 'bathrooms': str})
+    except ValueError:
+        rentals = pd.read_csv(
+            input_data_dir + csv_fnames['rentals'],
+            index_col=0, dtype={
+                'date': str, 'region': str,
+                'neighborhood': str, 'rent': float, 'sqft': float,
+                'rent_sqft': float, 'longitude': float,
+                'latitude': float, 'county': str, 'fips_block': str,
+                'state': str, 'bathrooms': str})
 
-# nodessmall = pd.read_csv(
-#     d + 'bay_area_tertiary_strongly_nodes.csv').set_index('osmid')
-# edgessmall = pd.read_csv(
-#     d + 'bay_area_tertiary_strongly_edges.csv').set_index('uniqueid')
+    units = pd.read_csv(
+        input_data_dir + csv_fnames['units'], index_col='unit_id',
+        dtype={'unit_id': int, 'building_id': int})
 
-skims = pd.read_csv(local_data_dir + csv_fnames['skims'], index_col=0)
-beam_skims = pd.read_csv(
-    local_data_dir + csv_fnames['beam_skims'])
+    try:
+        households = pd.read_csv(
+            input_data_dir + csv_fnames['households'],
+            index_col='household_id', dtype={
+                'household_id': int, 'block_group_id': str, 'state': str,
+                'county': str, 'tract': str, 'block_group': str,
+                'building_id': int, 'unit_id': int, 'persons': float})
+    except ValueError:
+        households = pd.read_csv(
+            input_data_dir + csv_fnames['households'],
+            index_col=0, dtype={
+                'household_id': int, 'block_group_id': str, 'state': str,
+                'county': str, 'tract': str, 'block_group': str,
+                'building_id': int, 'unit_id': int, 'persons': float})
+        households.index.name = 'household_id'
 
-store = pd.HDFStore('../data/baus_model_data_2025.h5')
-store.put('parcels', parcels)
-store.put('buildings_preproc', buildings)
-# store.put('building_types', building_types)
-store.put('units', units)
-store.put('rentals', rentals)
-store.put('households_preproc', households)
-store.put('persons', persons)
-store.put('jobs_preproc', jobs)
-store.put('establishments', establishments)
-# store.put('nodesbeam',nodesbeam)
-# store.put('edgesbeam',edgesbeam)
-# store.put('nodeswalk',nodeswalk)
-# store.put('edgeswalk',edgeswalk)
-# store.put('nodessmall',nodessmall)
-# store.put('edgessmall',edgessmall)
-store.put('skims', skims)
-store.put('zones', zones)
-store.put('beam_skims', beam_skims)
-store.keys()
+    try:
+        persons = pd.read_csv(
+            input_data_dir + csv_fnames['persons'], index_col='person_id',
+            dtype={'person_id': int, 'household_id': int})
+    except ValueError:
+        persons = pd.read_csv(
+            input_data_dir + csv_fnames['persons'], index_col=0,
+            dtype={'person_id': int, 'household_id': int})
+        persons.index.name = 'person_id'
 
-store.close()
+    try:
+        jobs = pd.read_csv(
+            input_data_dir + csv_fnames['jobs'], index_col='job_id',
+            dtype={'job_id': int, 'building_id': int})
+    except ValueError:
+        jobs = pd.read_csv(
+            input_data_dir + csv_fnames['jobs'], index_col=0,
+            dtype={'job_id': int, 'building_id': int})
+        jobs.index.name = 'job_id'
+
+    establishments = pd.read_csv(
+        input_data_dir + csv_fnames['establishments'],
+        index_col='establishment_id', dtype={
+            'establishment_id': int, 'building_id': int,
+            'primary_id': int})
+
+    zones = pd.read_csv(
+        input_data_dir + 'zones.csv', index_col='zone_id')
+
+    mtc_skims = pd.read_csv(
+        input_data_dir + csv_fnames['mtc_skims'], index_col=0)
+
+    beam_skims_raw = pd.read_csv(
+        input_data_dir + csv_fnames['beam_skims_raw'])
+    beam_skims_raw.rename(columns={
+        'generalizedCost': 'gen_cost', 'origTaz': 'from_zone_id',
+        'destTaz': 'to_zone_id'}, inplace=True)
+
+    # this data store is just a temp file that only needs to exist
+    # while the simulation is running. data is stored as csv's
+    # before and afterwards. therefore a temporary, relative filepath
+    # is specified here.
+
+    output_filepath = os.path.join(output_data_dir, data_store_fname)
+    if os.path.exists(output_filepath):
+        os.remove(output_filepath)
+        print('Deleting existing data store to create the new one...')
+    store = pd.HDFStore(output_filepath)
+
+    store.put('parcels', parcels, format='t')
+    store.put('units', units, format='t')
+    store.put('rentals', rentals, format='t')
+
+    # data pre-processing hasn't yet taken place if
+    # starting with base-year input data
+    if baseyear:
+
+        store.put('households', households, format='t')
+        store.put('jobs', jobs, format='t')
+        store.put('buildings', buildings, format='t')
+
+    # if starting from non-base-year (i.e. intra-simulation) data
+    # then the pre-processing data steps should have already
+    # occurred and we simply rename the main data tables so that
+    # bayarea_urbansim doesn't try to re-pre-process them
+    else:
+
+        store.put('households_preproc', households, format='t')
+        store.put('jobs_preproc', jobs, format='t')
+        store.put('buildings_preproc', buildings, format='t')
+
+    store.put('persons', persons, format='t')
+    store.put('establishments', establishments, format='t')
+    store.put('mtc_skims', mtc_skims, format='t')
+    store.put('zones', zones, format='t')
+    store.put('beam_skims_raw', beam_skims_raw, format='t')
+
+    if nodes_and_edges:
+
+        drive_nodes = pd.read_csv(
+            input_data_dir + csv_fnames['drive_nodes']).set_index('osmid')
+        drive_edges = pd.read_csv(
+            input_data_dir + csv_fnames['drive_edges']).set_index('uniqueid')
+        walk_nodes = pd.read_csv(
+            input_data_dir + csv_fnames['walk_nodes']).set_index('osmid')
+        walk_edges = pd.read_csv(
+            input_data_dir + csv_fnames['walk_edges']).set_index('uniqueid')
+
+        store.put('drive_nodes', drive_nodes, format='t')
+        store.put('drive_edges', drive_edges, format='t')
+        store.put('walk_nodes', walk_nodes, format='t')
+        store.put('walk_edges', walk_edges, format='t')
+
+    store.keys()
+
+    store.close()
+    print('UrbanSim model data now available at {0}'.format(
+        os.path.abspath(output_filepath)))


### PR DESCRIPTION
This PR brings the ual fork of bayarea_urbansim up to speed with the work developing PILATES. Changes are mostly a lot of cleanup of MTC's baus.py (still a lot of work to be done here) including the addition/subtraction of command line arguments, a refactoring of skim-based accessibility vars that leverages some imputation code stored in utils.py, and some changes to the usual suspects (datasources.py, models.py). Shouldn't break much if you had master running already.