### PR TITLE
fixed from the right upstream branch

### DIFF
--- a/baus/utils.py
+++ b/baus/utils.py
@@ -512,6 +512,20 @@ def impute_missing_skims(mtc_skims, beam_skims_raw):
     # miles to meters
     mtc['dist'] = mtc['da_distance_AM'] * 1609.34
 
+    # impute mtc zone-to-zone distances where zero-valued in beam skims
+    try:
+        df.loc[df['distanceInM'] == 0, 'distanceInM'] = mtc.loc[
+            pd.MultiIndex.from_frame(df.loc[df['distanceInM'] == 0, [
+                'from_zone_id', 'to_zone_id']]), 'dist'].values
+
+    # older versions of pandas don't have MultiIndex.from_frame()
+    except AttributeError:
+        df.loc[df['distanceInM'] == 0, 'distanceInM'] = mtc.loc[
+            pd.MultiIndex.from_arrays(list(zip(*df.loc[
+                df['distanceInM'] == 0,
+                ['from_zone_id', 'to_zone_id']].values))),
+            'dist'].values
+
     # create morning peak lookup
     df['gen_time_per_m'] = df['gen_tt'] / df['distanceInM']
     df['gen_cost_per_m'] = df['gen_cost'] / df['distanceInM']


### PR DESCRIPTION
imputes zero-valued zone-to-zone distances in beam skims with values from MTC skims